### PR TITLE
Avoiding shadowing python list keyword with method

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/postera/molecule_set.py
+++ b/asapdiscovery-data/asapdiscovery/data/postera/molecule_set.py
@@ -129,7 +129,7 @@ class MoleculeSetAPI(PostEraAPI):
 
         return results
 
-    def list(self, return_full: bool = False) -> Union[list[dict], dict]:
+    def list_available(self, return_full: bool = False) -> Union[list[dict], dict]:
         """List available MoleculeSets.
 
         Parameters
@@ -234,7 +234,7 @@ class MoleculeSetAPI(PostEraAPI):
 
     def update_molecules(
         self, molecule_set_id: str, data: MoleculeUpdateList, overwrite=False
-    ):
+    ) -> list[str]:
         """Updates the custom data associated with the Molecules in a MoleculeSet.
 
         Parameters

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_postera.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_postera.py
@@ -134,7 +134,7 @@ class TestMoleculeSet:
             },
         }
 
-        output = moleculesetapi.list()
+        output = moleculesetapi.list_available()
 
         assert output == {"497f6eca-6276-4993-bfeb-53cbbbba6f08": "test_set"}
 


### PR DESCRIPTION
## Description
We shouldn't shadow `list` or any python keywords. This changes the `list` method from `MoleculeSetAPI` to `list_available`.

Resolves #156 

## Status
- [x] Ready to go
