### PR TITLE
Change OE imports to be namespaced under `asapdiscovery` for license check. 

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/openeye.py
@@ -1,4 +1,4 @@
-from openeye import oechem, oedepict, oedocking, oegrid, oespruce  # noqa: E401
+from openeye import oechem, oegrid, oedocking, oespruce, oedepict # noqa: F401
 
 # exec on module import
 if not oechem.OEChemIsLicensed("python"):

--- a/asapdiscovery-data/asapdiscovery/data/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/openeye.py
@@ -1,4 +1,4 @@
-from openeye import oechem, oegrid, oedocking, oespruce, oedepict # noqa: E401
+from openeye import oechem, oedepict, oedocking, oegrid, oespruce  # noqa: E401
 
 # exec on module import
 if not oechem.OEChemIsLicensed("python"):

--- a/asapdiscovery-data/asapdiscovery/data/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/openeye.py
@@ -1,4 +1,4 @@
-from openeye import oechem, oegrid, oedocking, oespruce, oedepict # noqa: F401
+from openeye import oechem, oedepict, oedocking, oegrid, oespruce  # noqa: F401
 
 # exec on module import
 if not oechem.OEChemIsLicensed("python"):

--- a/asapdiscovery-data/asapdiscovery/data/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/openeye.py
@@ -1,4 +1,4 @@
-from openeye import oechem, oegrid
+from openeye import oechem, oegrid, oedocking, oespruce, oedepict
 
 # exec on module import
 if not oechem.OEChemIsLicensed("python"):

--- a/asapdiscovery-data/asapdiscovery/data/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/openeye.py
@@ -1,4 +1,4 @@
-from openeye import oechem, oegrid, oedocking, oespruce, oedepict
+from openeye import oechem, oegrid, oedocking, oespruce, oedepict # noqa: E401
 
 # exec on module import
 if not oechem.OEChemIsLicensed("python"):

--- a/asapdiscovery-data/asapdiscovery/data/utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/utils.py
@@ -13,7 +13,7 @@ from asapdiscovery.data.schema import (
     ExperimentalCompoundData,
     ExperimentalCompoundDataUpdate,
 )
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 
 def download_file(url: str, path: str):

--- a/asapdiscovery-docking/asapdiscovery/docking/analysis.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/analysis.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 import pandas as pd
 from asapdiscovery.data.openeye import get_ligand_rmsd_from_pdb_and_sdf
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 
 class DockingDataset:

--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -47,7 +47,7 @@ def run_docking_oe(
         Generated docking_id, used to access SD tag data
     """
     from asapdiscovery.docking.analysis import calculate_rmsd_openeye
-    from openeye import oechem, oedocking
+    from asapdiscovery.data.openeye import oechem, oedocking
 
     # Make copy so we can keep the original for RMSD purposes
     orig_mol = orig_mol.CreateCopy()

--- a/asapdiscovery-docking/asapdiscovery/docking/mcs.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/mcs.py
@@ -40,7 +40,7 @@ def rank_structures_openeye(
         Index that sorts `sort_smis` by decreasing similarity with `exp_smi`
         based on MCS search.
     """
-    from openeye import oechem, oedepict
+    from asapdiscovery.data.openeye import oechem, oedepict
 
     if smi_conv is None:
         smi_conv = _smi_conv_oe

--- a/asapdiscovery-docking/asapdiscovery/docking/modeling.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/modeling.py
@@ -3,7 +3,7 @@ from asapdiscovery.data.openeye import (
     load_openeye_sdf,
     split_openeye_mol,
 )
-from openeye import oechem, oedocking, oespruce
+from asapdiscovery.data.openeye import oechem, oedocking, oespruce
 
 
 def du_to_complex(du, include_solvent=False):

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/build_design_units.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/build_design_units.py
@@ -1,7 +1,8 @@
 import argparse
 import os
 
-from openeye import oechem, oespruce
+from asapdiscovery.data.openeye import oechem, oedocking, oegrid, oespruce
+
 
 
 ########################################

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/build_design_units.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/build_design_units.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from asapdiscovery.data.openeye import oechem, oedocking, oegrid, oespruce
+from asapdiscovery.data.openeye import oechem, oespruce
 
 
 

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/fauxalysis_from_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/fauxalysis_from_docking.py
@@ -18,7 +18,7 @@ import shutil
 import sys
 
 import yaml
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 repo_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(repo_path)

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/make_docked_complexes.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/make_docked_complexes.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 import pandas
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from asapdiscovery.data.openeye import load_openeye_pdb  # noqa: E402

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/prep_fragalysis_dus.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/prep_fragalysis_dus.py
@@ -11,7 +11,7 @@ import sys
 from tempfile import NamedTemporaryFile
 
 import yaml
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from asapdiscovery.data.fragalysis import parse_xtal  # noqa: E402

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/prep_proteins.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/prep_proteins.py
@@ -20,7 +20,7 @@ import re
 import sys
 
 import yaml
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from asapdiscovery.data import pdb  # noqa: E402

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -11,7 +11,7 @@ import sys
 from glob import glob
 
 import pandas
-from openeye import oechem
+from asapdiscovery.data.openeye import oechem
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from asapdiscovery.data.openeye import load_openeye_sdf  # noqa: E402

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/score_structures.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/score_structures.py
@@ -1,8 +1,9 @@
 import argparse
 
 import pandas
+from asapdiscovery.data.openeye import oechem, oedocking, oegrid
 from asapdiscovery.data.openeye import load_openeye_pdb, split_openeye_mol
-from openeye import oechem, oedocking, oegrid
+
 
 SCORE_TYPES = {
     "chemgauss": oedocking.OEScoreType_Chemgauss4,

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/test-protein-prep.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/test-protein-prep.py
@@ -17,7 +17,7 @@ from asapdiscovery.docking.modeling import align_receptor  # noqa: 402
 from asapdiscovery.docking.modeling import du_to_complex  # noqa: E402
 from asapdiscovery.docking.modeling import mutate_residues  # noqa: E402
 from asapdiscovery.docking.modeling import prep_receptor  # noqa: E402
-from openeye import oechem  # noqa: E402
+from asapdiscovery.data.openeye import oechem  # noqa: E402
 
 
 def get_args():


### PR DESCRIPTION
Fixes #155 

## TODO
- [x] Do some final checks to make sure everything works 

## Description

Moves all openeye imports to be namespaced under our openeye wrapper so that the license can be checked at import time. 

Tagging @apayne97, @kaminow @ijpulidos @dotsdl @mikemhenry so that y'all are aware that this is how OE stuff should be imported from now on.

```python
from asapdiscovery.data.openeye import oefoo, oebar
```