### PR TITLE
Add early stopping

### DIFF
--- a/asapdiscovery/ml/__init__.py
+++ b/asapdiscovery/ml/__init__.py
@@ -1,2 +1,3 @@
 from .loss import *
 from .models import *
+from .es import EarlyStopping

--- a/asapdiscovery/ml/es.py
+++ b/asapdiscovery/ml/es.py
@@ -41,7 +41,7 @@ class EarlyStopping(object):
         # If this is the first epoch, just set internal variables and return
         if self.best_loss is None:
             self.best_loss = loss
-            self.best_wts = best_wts
+            self.best_wts = wts_dict
             return False
 
         # Update best loss and best weights

--- a/asapdiscovery/ml/es.py
+++ b/asapdiscovery/ml/es.py
@@ -21,8 +21,9 @@ class EarlyStopping(object):
         self.counter = 0
         self.best_loss = None
         self.best_wts = None
+        self.best_epoch = 0
 
-    def check(self, loss, wts_dict):
+    def check(self, epoch, loss, wts_dict):
         """
         Check if training should be stopped. Return True to stop, False to keep going.
 
@@ -48,6 +49,7 @@ class EarlyStopping(object):
         if loss < self.best_loss:
             self.best_loss = loss
             self.best_wts = wts_dict
+            self.best_epoch = epoch
 
             # Reset counter
             self.counter = 0

--- a/asapdiscovery/ml/es.py
+++ b/asapdiscovery/ml/es.py
@@ -1,0 +1,63 @@
+"""
+Class for handling early stopping in training.
+"""
+
+
+class EarlyStopping(object):
+    """Class for handling early stopping in training."""
+
+    def __init__(self, patience):
+        """
+        Parameters
+        ----------
+        patience : int, optional
+            The maximum number of epochs to continue training with no improvement in the
+            val loss. If not given, no early stopping will be performed
+        """
+        super(EarlyStopping, self).__init__()
+        self.patience = patience
+
+        # Variables to track early stopping
+        self.counter = 0
+        self.best_loss = None
+        self.best_wts = None
+
+    def check(loss, wts_dict):
+        """
+        Check if training should be stopped. Return True to stop, False to keep going.
+
+        Parameters
+        ----------
+        loss : float
+            Model loss from the current epoch of training
+        wts_dict : dict
+            Weights dict from Pytorch for keeping track of the best model
+
+        Returns
+        -------
+        bool
+            Whether to stop training
+        """
+        # If this is the first epoch, just set internal variables and return
+        if self.best_loss is None:
+            self.best_loss = loss
+            self.best_wts = best_wts
+            return False
+
+        # Update best loss and best weights
+        if loss < self.best_loss:
+            self.best_loss = loss
+            self.best_wts = wts_dict
+
+            # Reset counter
+            self.counter = 0
+
+            # Keep training
+            return False
+
+        # Increment counter and check for stopping
+        self.counter += 1
+        if self.counter == self.patience:
+            return True
+
+        return False

--- a/asapdiscovery/ml/es.py
+++ b/asapdiscovery/ml/es.py
@@ -22,7 +22,7 @@ class EarlyStopping(object):
         self.best_loss = None
         self.best_wts = None
 
-    def check(loss, wts_dict):
+    def check(self, loss, wts_dict):
         """
         Check if training should be stopped. Return True to stop, False to keep going.
 

--- a/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery/ml/scripts/train.py
@@ -262,7 +262,7 @@ def get_args():
     )
     parser.add_argument(
         "-es",
-        "--early-stopping",
+        "--early_stopping",
         type=int,
         help="Number of training epochs to allow with no improvement in val loss.",
     )

--- a/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery/ml/scripts/train.py
@@ -657,6 +657,9 @@ def main():
     if args.wandb or args.sweep:
         wandb.finish()
 
+    # Save model weights
+    torch.save(model.state_dict(), f"{model_dir}/final.th")
+
     ## Plot loss
     if args.plot_o is not None:
         plot_loss(

--- a/asapdiscovery/ml/utils.py
+++ b/asapdiscovery/ml/utils.py
@@ -1432,7 +1432,7 @@ def train(
         # Stop training if EarlyStopping says to
         if es and es.check(epoch_val_loss, model.state_dict()):
             print(f"Stopping training after epoch {epoch_idx}", flush=True)
-            model.load_state_dict(es.wts_dict)
+            model.load_state_dict(es.best_wts)
             break
 
     return (

--- a/asapdiscovery/ml/utils.py
+++ b/asapdiscovery/ml/utils.py
@@ -1357,10 +1357,6 @@ def train(
             val_loss.append(np.asarray(tmp_loss))
             epoch_val_loss = np.mean(tmp_loss)
 
-            ## Check about early stopping
-            if es:
-                stop_training = es.check(epoch_val_loss, model.state_dict())
-
             tmp_loss = []
             for compound, pose in ds_test:
                 if type(compound) is tuple:
@@ -1434,7 +1430,7 @@ def train(
             raise ValueError("Unrecoverable loss value reached.")
 
         # Stop training if EarlyStopping says to
-        if es and stop_training:
+        if es and es.check(epoch_val_loss, model.state_dict()):
             print(f"Stopping training after epoch {epoch_idx}", flush=True)
             model.load_state_dict(es.wts_dict)
             break

--- a/asapdiscovery/ml/utils.py
+++ b/asapdiscovery/ml/utils.py
@@ -1430,8 +1430,14 @@ def train(
             raise ValueError("Unrecoverable loss value reached.")
 
         # Stop training if EarlyStopping says to
-        if es and es.check(epoch_val_loss, model.state_dict()):
-            print(f"Stopping training after epoch {epoch_idx}", flush=True)
+        if es and es.check(epoch_idx, epoch_val_loss, model.state_dict()):
+            print(
+                (
+                    f"Stopping training after epoch {epoch_idx}, "
+                    f"using weights from epoch {es.best_epoch}"
+                ),
+                flush=True,
+            )
             model.load_state_dict(es.best_wts)
             break
 


### PR DESCRIPTION
Implement early stopping when training a model. Stops training when `val_loss` is no longer increasing. Also, `train.py` now saves the final model weights as `final.th`.