### PR TITLE
Improve GAT model

### DIFF
--- a/asapdiscovery/ml/loss/MSELoss.py
+++ b/asapdiscovery/ml/loss/MSELoss.py
@@ -79,12 +79,18 @@ class MSELoss(TorchMSELoss):
         ##  1.0 - If input or data is semiquant and prediction is inside the
         ##    assay range
         ##  0.0 - If data is semiquant and prediction is outside the assay range
+        # r < 0 -> measurement is below thresh, want to count if pred > target
+        # r > 0 -> measurement is above thresh, want to count if pred < target
         mask = torch.tensor(
             [
                 1.0 if r == 0 else ((r < 0) == (t < i))
                 for i, t, r in zip(input, target, in_range)
             ]
         )
-        mask = mask.to(loss.device)
+        mask = mask.to(input.device)
 
-        return (mask * loss).mean()
+        # Need to add the max in the denominator in case there are no values that we
+        #  want to calculate loss for
+        loss = (loss * mask) / max(torch.sum(mask), 1)
+
+        return loss

--- a/asapdiscovery/ml/models/GAT.py
+++ b/asapdiscovery/ml/models/GAT.py
@@ -40,9 +40,6 @@ class GAT(torch.nn.Module):
         device = next(self.parameters()).device
         g = g.to(device)
         feats = feats.to(device)
-        ### doesn't work bc GATPredictor calls torch.functional.batch_norm,
-        ###  which requires multiple channels (which we don't have)
-        # return super(GAT, self).forward(g, feats)
         node_feats = self.gnn(g, feats)
         graph_feats = self.readout(g, node_feats)
         return self.predict(graph_feats)

--- a/asapdiscovery/ml/models/GAT.py
+++ b/asapdiscovery/ml/models/GAT.py
@@ -1,7 +1,6 @@
 from dgllife.model import GAT as GAT_dgl
 from dgllife.model import WeightedSumAndMax
 
-# from dgllife.model import GATPredictor
 import torch
 
 
@@ -11,7 +10,6 @@ class GAT(torch.nn.Module):
     """
 
     def __init__(self, *args, **kwargs):
-        # super(GAT, self).__init__(*args, **kwargs)
         super(GAT, self).__init__()
         self.gnn = GAT_dgl(*args, **kwargs)
 

--- a/asapdiscovery/ml/models/GAT.py
+++ b/asapdiscovery/ml/models/GAT.py
@@ -1,4 +1,7 @@
 from dgllife.model import GAT as GAT_dgl
+from dgllife.model import WeightedSumAndMax
+
+# from dgllife.model import GATPredictor
 import torch
 
 
@@ -8,14 +11,27 @@ class GAT(torch.nn.Module):
     """
 
     def __init__(self, *args, **kwargs):
+        # super(GAT, self).__init__(*args, **kwargs)
         super(GAT, self).__init__()
         self.gnn = GAT_dgl(*args, **kwargs)
-        self.readout = torch.nn.Linear(self.gnn.hidden_feats[-1], 1)
+
+        # Copied from GATPredictor class, figure out how many features the last
+        #  layer of the GNN will have
+        if self.gnn.agg_modes[-1] == "flatten":
+            gnn_out_feats = self.gnn.hidden_feats[-1] * self.gnn.num_heads[-1]
+        else:
+            gnn_out_feats = self.gnn.hidden_feats[-1]
+        self.readout = WeightedSumAndMax(gnn_out_feats)
+
+        self.predict = torch.nn.Linear(2 * gnn_out_feats, 1)
 
     def forward(self, g, feats):
         device = next(self.parameters()).device
         g = g.to(device)
         feats = feats.to(device)
-        node_preds = self.gnn(g, feats)
-        node_preds = self.readout(node_preds)
-        return node_preds.sum(dim=0)
+        ### doesn't work bc GATPredictor calls torch.functional.batch_norm,
+        ###  which requires multiple channels (which we don't have)
+        # return super(GAT, self).forward(g, feats)
+        node_feats = self.gnn(g, feats)
+        graph_feats = self.readout(g, node_feats)
+        return self.predict(graph_feats)

--- a/asapdiscovery/ml/utils.py
+++ b/asapdiscovery/ml/utils.py
@@ -994,7 +994,7 @@ def plot_loss(train_loss, val_loss, test_loss, out_fn):
     sns.lineplot(x=range(len(val_loss)), y=val_loss, ax=axes[1])
     sns.lineplot(x=range(len(test_loss)), y=test_loss, ax=axes[2])
 
-    for (ax, loss_type) in zip(axes, ("Training", "Validation", "Test")):
+    for ax, loss_type in zip(axes, ("Training", "Validation", "Test")):
         ax.set_ylabel(f"MSE {loss_type} Loss")
         ax.set_xlabel("Epoch")
         ax.set_title(f"MSE {loss_type} Loss")
@@ -1266,6 +1266,7 @@ def train(
 
     if loss_fn is None:
         loss_fn = MSELoss()
+    print("Using loss functions", loss_fn, flush=True)
 
     ## Train for n epochs
     for epoch_idx in range(start_epoch, n_epochs):

--- a/asapdiscovery/ml/utils.py
+++ b/asapdiscovery/ml/utils.py
@@ -1266,7 +1266,7 @@ def train(
 
     if loss_fn is None:
         loss_fn = MSELoss()
-    print("Using loss functions", loss_fn, flush=True)
+    print("Using loss function", loss_fn, flush=True)
 
     ## Train for n epochs
     for epoch_idx in range(start_epoch, n_epochs):


### PR DESCRIPTION
Improve the GAT model by using a 2 layer MLP with ReLU activation instead of the single linear layer previously being used. This makes things more in line with the [GATPredictor](https://github.com/awslabs/dgl-lifesci/blob/master/python/dgllife/model/model_zoo/gat_predictor.py) class from `dgl-lifesci`.

Also adjusted the MSELoss class to make sure that averages are calculated correctly when there are multiple predictions.