### PR TITLE
first steps in building sequential docking fn

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -198,9 +198,10 @@ def mp_func(out_dir, lig_name, du_name, *args, **kwargs):
     pkl.dump(results, open(os.path.join(out_dir, "results.pkl"), "wb"))
     return results
 
+
 def dock_sequentially(out_dir, lig_name, du_name, *args, **kwargs):
     """
-    Sequential function for docking. 
+    Sequential function for docking.
 
     Parameters
     ----------
@@ -482,9 +483,6 @@ def main():
         print(f"Running {len(mp_args)} docking runs sequentially.")
         results_df = dock_sequentially(mp_args)
 
-
-
-        
     else:
         print(f"Running {len(mp_args)} docking runs over {nprocs} cores.")
         with mp.Pool(processes=nprocs) as pool:


### PR DESCRIPTION
## Description
When debugging the multiprocessing function in `run_docking_oe.py` it becomes unnecessarily complex to figure out what's going wrong in daughter processes. It's more efficient to be able to check if a non-multiprocessed job is failing (and to see direct error logs); this PR implements that functionality.

We'll set `-n 0` to be the flag to disable multiprocessing.

## Todos
  - [ ] write base function and debug
  - [ ] test on use-case

## Status
- [ ] Ready to go
