### PR TITLE
Add GAT model at newest version for migration to MTENN

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -71,7 +71,6 @@ def run_docking_oe(
     from asapdiscovery.data.openeye import oechem, oedocking
     from asapdiscovery.docking.analysis import calculate_rmsd_openeye
 
-    logger.info(oechem.OEThrow.OEErrorHandlerImplBase)
     oechem.OEThrow.Debug("Confirm that OE logging is working")
 
     # Make copy so we can keep the original for RMSD purposes

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -261,7 +261,7 @@ def parse_du_filenames(receptors, regex, basefile="predocked.oedu"):
 
     # check that we actually have loaded in prepped receptors.
     check_filelist_has_elements(all_fns, tag="prepped receptors")
-    logger.info(f"{len(all_fns)} DesignUnit files found", flush=True)
+    logger.info(f"{len(all_fns)} DesignUnit files found")
 
     # Build regex search function
     regex_func = construct_regex_function(regex, ret_groups=True)

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -456,7 +456,7 @@ def main():
     n_mols = len(mols)
 
     # Set up ML model
-    gat_model_string = "asapdiscovery-GAT-2023.04.12"
+    gat_model_string = "asapdiscovery-GAT-2023.04.20"
     if args.gat:
         GAT_model = GATInference(gat_model_string)
         logger.info(f"Using GAT model: {gat_model_string}")

--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -456,7 +456,7 @@ def main():
     n_mols = len(mols)
 
     # Set up ML model
-    gat_model_string = "asapdiscovery-GAT-2023.04.20"
+    gat_model_string = "asapdiscovery-GAT-2023.04.12"
     if args.gat:
         GAT_model = GATInference(gat_model_string)
         logger.info(f"Using GAT model: {gat_model_string}")

--- a/asapdiscovery-ml/asapdiscovery/ml/models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.yaml
@@ -39,3 +39,16 @@ asapdiscovery-GAT-2023.04.12:
     resource: asapdiscovery-GAT-config-2023.04.12.json
     sha256hash: d0b4d6c1f74b3e9caacea50af6ff6927803143842a72e74ebc7dbefdb2bcf444
   last_updated: 2023-04-12
+
+
+# asapdiscovery-GAT-2023.04.20 model
+asapdiscovery-GAT-2023.04.20:
+  type: GAT
+  base_url: https://asap-discovery-ml-weights.s3.amazonaws.com/production/GAT/
+  weights:
+    resource: asapdiscovery-GAT-2023.04.20.th
+    sha256hash: d1bc5f0ba286804c6ce6c0b05d8a0ed843d24e9e9e9f50188c081d0112fc057b
+  config:
+    resource: asapdiscovery-GAT-config-2023.04.20.json
+    sha256hash: d0b4d6c1f74b3e9caacea50af6ff6927803143842a72e74ebc7dbefdb2bcf444
+  last_updated: 2023-04-20


### PR DESCRIPTION
Updates the gat model spec and fixes two random logging issues.

Will likely have to go in before #231 and then we can update the docking workflow to the new model in #231. 

If the old models will not be backward compatible as we are pre 0.1.0 we can just chop them out. 