### PR TITLE
Fix issue 260

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -551,7 +551,7 @@ def main():
     logger.info(f"Loaded {n_mols} ligands, proceeding with docking setup")
 
     # Set up ML model
-    gat_model_string = "asapdiscovery-GAT-2023.04.12"
+    gat_model_string = "asapdiscovery-GAT-2023.05.09"
     if args.gat:
         from asapdiscovery.ml.inference import GATInference  # noqa: E402
 

--- a/asapdiscovery-ml/asapdiscovery/ml/models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.yaml
@@ -62,3 +62,15 @@ asapdiscovery-schnet-2023.04.29:
     resource: asapdiscovery-schnet-2023.04.29.th
     sha256hash: be13aeaea6c9d21dad7a82ee4a614999622e901b097a895144ee34a1ff8b5fba
   last_updated: 2023-04-29
+
+# asapdiscovery-GAT-2023.05.09 model
+asapdiscovery-GAT-2023.05.09:
+  type: GAT
+  base_url: https://asap-discovery-ml-weights.s3.amazonaws.com/production/GAT/
+  weights:
+    resource: asapdiscovery-GAT-2023.05.09.th
+    sha256hash: 4294902bcfbf95224edf1003207de839cdd2893772973aacc2a7ecbeb277da76
+  config:
+    resource: asapdiscovery-GAT-config-2023.05.09.json
+    sha256hash: d0b4d6c1f74b3e9caacea50af6ff6927803143842a72e74ebc7dbefdb2bcf444
+  last_updated: 2023-05-09

--- a/asapdiscovery-ml/asapdiscovery/ml/models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.yaml
@@ -63,6 +63,8 @@ asapdiscovery-schnet-2023.04.29:
     sha256hash: be13aeaea6c9d21dad7a82ee4a614999622e901b097a895144ee34a1ff8b5fba
   last_updated: 2023-04-29
 
+
+# Earlier models will not work with DGL >1.1 due to changes in their code
 # asapdiscovery-GAT-2023.05.09 model
 asapdiscovery-GAT-2023.05.09:
   type: GAT

--- a/asapdiscovery-ml/asapdiscovery/ml/models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.yaml
@@ -14,7 +14,7 @@ gat_test_v0:
   # The weights key has the name of the weights file and the sha256 hash of the file.
   weights:
     # resource is the name of the file
-    resource: gat_example.pth
+    resource: gat_example_dgl1.1.pth
     # sha256hash is the sha256 hash of the file
     sha256hash: 38e5476ede0ed67ad0951d5d1c7c913ecf0aeaa6a1913d16ee9dca28b5d9795b
   # The config key has the name of the config file and the sha256 hash of the file.

--- a/asapdiscovery-ml/asapdiscovery/ml/models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.yaml
@@ -16,7 +16,7 @@ gat_test_v0:
     # resource is the name of the file
     resource: gat_example_dgl1.1.pth
     # sha256hash is the sha256 hash of the file
-    sha256hash: 38e5476ede0ed67ad0951d5d1c7c913ecf0aeaa6a1913d16ee9dca28b5d9795b
+    sha256hash: 4294902bcfbf95224edf1003207de839cdd2893772973aacc2a7ecbeb277da76
   # The config key has the name of the config file and the sha256 hash of the file.
   # This key is optional
   config:

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
@@ -54,7 +54,7 @@ def test_gatinference_predict_smiles_equivariant(weights_yaml, test_data):
     assert inference_cls is not None
     output1 = inference_cls.predict(g1)
     output2 = inference_cls.predict(g2)
-    assert_allclose(output1, output2)
+    assert_allclose(output1, output2, rtol=1e-5)
 
 
 # test inference dataset cls against training dataset cls
@@ -69,22 +69,22 @@ def test_gatinference_predict_dataset(weights_yaml, test_data, test_inference_da
     output1 = inference_cls.predict(g1)
     output2 = inference_cls.predict(g2)
     output3 = inference_cls.predict(g3)
-    assert_allclose(output1, output2)
+    assert_allclose(output1, output2, rtol=1e-5)
 
     # test inference dataset
     output_infds_1 = inference_cls.predict(g1_infds)
     output_infds_2 = inference_cls.predict(g2_infds)
     output_infds_3 = inference_cls.predict(g3_infds)
-    assert_allclose(output_infds_1, output_infds_2)
+    assert_allclose(output_infds_1, output_infds_2, rtol=1e-5)
 
     # test that the ones that should be the same are
-    assert_allclose(output1, output_infds_1)
-    assert_allclose(output2, output_infds_2)
-    assert_allclose(output3, output_infds_3)
+    assert_allclose(output1, output_infds_1, rtol=1e-5)
+    assert_allclose(output2, output_infds_2, rtol=1e-5)
+    assert_allclose(output3, output_infds_3, rtol=1e-5)
 
     # test that the ones that should be different are
-    assert not np.allclose(output3, output1)
-    assert not np.allclose(output3, output2)
+    assert not np.allclose(output3, output1, rtol=1e-5)
+    assert not np.allclose(output3, output2, rtol=1e-5)
 
 
 def test_gatinference_predict_from_smiles_dataset(
@@ -103,29 +103,30 @@ def test_gatinference_predict_from_smiles_dataset(
     # smiles one and two are the same
     output1 = inference_cls.predict(gids[s1])
     output2 = inference_cls.predict(gids[s2])
-    assert_allclose(output1, output2)
+    assert_allclose(output1, output2, rtol=1e-5)
 
     # smiles one and three are different
     s3 = smiles[2]
     output3 = inference_cls.predict(gids[s3])
-    assert not np.allclose(output3, output1)
+    assert not np.allclose(output3, output1, rtol=1e-5)
 
     # test predicting directly from smiles
     output_smiles_1 = inference_cls.predict_from_smiles(s1)
     output_smiles_2 = inference_cls.predict_from_smiles(s2)
     output_smiles_3 = inference_cls.predict_from_smiles(s3)
 
-    assert_allclose(output_smiles_1, output_smiles_2)
-    assert_allclose(output1, output_smiles_1)
+    assert_allclose(output_smiles_1, output_smiles_2, rtol=1e-5)
+    assert_allclose(output1, output_smiles_1, rtol=1e-5)
 
-    assert_allclose(output3, output_smiles_3)
-    assert not np.allclose(output_smiles_3, output_smiles_1)
-    assert not np.allclose(output3, output_smiles_1)
+    assert_allclose(output3, output_smiles_3, rtol=1e-5)
+    assert not np.allclose(output_smiles_3, output_smiles_1, rtol=1e-5)
+    assert not np.allclose(output3, output_smiles_1, rtol=1e-5)
 
     # test predicting list of similes
     output_arr = inference_cls.predict_from_smiles([s1, s2, s3])
     assert_allclose(
-        output_arr, np.asarray([output_smiles_1, output_smiles_2, output_smiles_3])
+        output_arr,
+        np.asarray([output_smiles_1, output_smiles_2, output_smiles_3], rtol=1e-5),
     )
 
 

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
@@ -126,7 +126,7 @@ def test_gatinference_predict_from_smiles_dataset(
     output_arr = inference_cls.predict_from_smiles([s1, s2, s3])
     assert_allclose(
         output_arr,
-        np.asarray([output_smiles_1, output_smiles_2, output_smiles_3], rtol=1e-5),
+        np.asarray([output_smiles_1, output_smiles_2, output_smiles_3]),
     )
 
 

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_weights.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_weights.yaml
@@ -24,7 +24,7 @@ gatmodel_test:
   base_url: https://asap-discovery-ml-weights.s3.amazonaws.com/test/
   type: GAT
   weights:
-    resource: gat_example.pth
+    resource: gat_example_dgl1.1.pth
     sha256hash: 38e5476ede0ed67ad0951d5d1c7c913ecf0aeaa6a1913d16ee9dca28b5d9795b
   config:
     resource: gat_example_config.json

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_weights.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_weights.yaml
@@ -25,7 +25,7 @@ gatmodel_test:
   type: GAT
   weights:
     resource: gat_example_dgl1.1.pth
-    sha256hash: 38e5476ede0ed67ad0951d5d1c7c913ecf0aeaa6a1913d16ee9dca28b5d9795b
+    sha256hash: 4294902bcfbf95224edf1003207de839cdd2893772973aacc2a7ecbeb277da76
   config:
     resource: gat_example_config.json
     sha256hash: d0b4d6c1f74b3e9caacea50af6ff6927803143842a72e74ebc7dbefdb2bcf444

--- a/devtools/conda-envs/asapdiscovery.yaml
+++ b/devtools/conda-envs/asapdiscovery.yaml
@@ -43,7 +43,7 @@ dependencies:
   - numpy
   - h5py
   - e3nn
-  - dgl <=1.0.2
+  - dgl
   - dgllife
   - pooch
 


### PR DESCRIPTION
Add new GAT weights that are compatible with the new version of `dgl`. Closes #260.