### PR TITLE
Improve loss tracking

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/plot_data_efficiency.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/plot_data_efficiency.py
@@ -5,6 +5,7 @@ Input CSV must have the columns:
  * train_frac
 """
 import argparse
+import json
 import os
 import pickle as pkl
 from functools import partial
@@ -145,6 +146,104 @@ def losses_to_df(losses):
         all_labs.extend([lab] * len(loss_arr))
 
     return pandas.DataFrame({"split": all_labs, "loss": all_losses})
+
+
+def load_losses_dict(loss_dir, conv_function=None, take_best=True):
+    """
+    Load train, val, and test losses from `loss_dir`/loss_dict.json, converting as
+    necessary. Take loss from epoch with best original val loss.
+
+    Parameters
+    ----------
+    loss_dir : str
+        Directory containing pickle files
+    conv_function : callable, optional
+        If present, will use to convert mean absolute loss values
+
+    Returns
+    -------
+    pandas.DataFrame
+        DF with losses for the best idx across all splits
+    """
+    try:
+        loss_dict = json.load(open(f"{loss_dir}/loss_dict.json"))
+    except FileNotFoundError:
+        raise FileNotFoundError(f"No loss_dict.json file found in {loss_dir}")
+
+    # Load per-epoch losses for each molecule, and transpose so each row is an epoch and
+    #  each col is a molecule
+    all_losses = np.asarray(
+        [v["losses"] for d in loss_dict.values() for v in d.values()]
+    ).T
+    all_compound_ids = np.asarray(
+        [compound_id for d in loss_dict.values() for compound_id in d]
+    )
+    split_label_dict = {
+        compound_id: sp for sp, d in loss_dict.items() for compound_id in d
+    }
+
+    # Build and rearrange DF
+    df = pandas.DataFrame(all_losses, columns=all_compound_ids)
+    df = df.reset_index().melt(
+        id_vars=["index"], var_name="compound_id", value_name="loss"
+    )
+    df["split"] = [split_label_dict[c] for c in df["compound_id"]]
+    df = df.rename(columns={"index": "epoch"})
+
+    # Take only best idx
+    if take_best:
+        # Get best epoch idx from val set
+        val_arr = np.asarray([v["losses"] for v in loss_dict["val"].values()]).T
+        best_idx = np.argmin(val_arr.mean(axis=1))
+        df = df.loc[df["epoch"] == best_idx, :]
+
+    # Convert losses if desired
+    if conv_function:
+        df.loc[:, "loss"] = df["loss"].pow(0.5).apply(conv_function)
+
+    return df
+
+
+def load_all_losses_dict(in_df, rel_dir=None, conv_function=None, take_best=True):
+    """
+    Load all train, val, and test losses, and build DataFrame.
+
+    Parameters
+    ----------
+    in_df : pandas.DataFrame
+        DataFrame containing loss_dir, label, train_frac
+    rel_dir : str, optional
+        Directory to which all paths in in_df are relative to. If present, will be
+        prepended to each path
+    conv_function : callable, optional
+        If present, will use to convert mean absolute loss values
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame ready with losses, labels, and train fracs
+    """
+    # Parametrize load_losses function
+    load_losses_param = partial(
+        load_losses_dict, conv_function=conv_function, take_best=take_best
+    )
+
+    all_dfs = []
+    for _, r in in_df.iterrows():
+        # Set up directory
+        d = r["loss_dir"]
+        if rel_dir:
+            d = os.path.join(rel_dir, d)
+
+        # Build melted loss DF
+        df = load_losses_param(d)
+
+        for c in r.index:
+            df[c] = r[c]
+
+        all_dfs.append(df)
+
+    return pandas.concat(all_dfs, axis=0, ignore_index=True)
 
 
 def plot_data_efficiency(plot_df, out_fn, max_loss=None, conv=False):

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/plot_data_efficiency.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/plot_data_efficiency.py
@@ -199,6 +199,7 @@ def load_losses_dict(loss_dir, conv_function=None, take_best=True):
 
     # Convert losses if desired
     if conv_function:
+        # Stored loss values are in squared pIC50 units, so take sqrt to get plain pIC50
         df.loc[:, "loss"] = df["loss"].pow(0.5).apply(conv_function)
 
     return df

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -460,7 +460,7 @@ def init(args, rank=False):
         model_config = {}
     print("Using model config:", model_config, flush=True)
 
-    # Override args parameters with model_config parameters\
+    # Override args parameters with model_config parameters
     # This shouldn't strictly be necessary, as model_config should override
     #  everything, but just to be safe
     if "grouped" in model_config:

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -8,7 +8,6 @@ python train.py \
     -i complex_structure_dir/ \
     -exp experimental_measurements.json \
     -model_o trained_schnet/ \
-    -plot_o trained_schnet/all_loss.png \
     -model schnet \
     -lig \
     -dg \
@@ -44,7 +43,6 @@ from asapdiscovery.ml.utils import (
     find_most_recent,
     load_weights,
     parse_config,
-    plot_loss,
     split_dataset,
     train,
 )
@@ -235,7 +233,6 @@ def get_args():
 
     # Output arguments
     parser.add_argument("-model_o", help="Where to save model weights.")
-    parser.add_argument("-plot_o", help="Where to save training loss plot.")
     parser.add_argument("-cache", help="Cache directory for dataset.")
 
     # Dataset arguments
@@ -439,13 +436,11 @@ def init(args, rank=False):
     os.makedirs(model_dir, exist_ok=True)
 
     # Parse model config
-
     if args.sweep and args.config:
         import wandb
 
         # Get both configs
         sweep_config = dict(wandb.config)
-
         model_config = parse_config(args.config)
 
         # Sweep config overrules CLI config
@@ -820,15 +815,6 @@ def main():
 
     # Save model weights
     torch.save(model.state_dict(), f"{model_dir}/final.th")
-
-    # Plot loss
-    if args.plot_o is not None:
-        plot_loss(
-            train_loss.mean(axis=1),
-            val_loss.mean(axis=1),
-            test_loss.mean(axis=1),
-            args.plot_o,
-        )
 
 
 if __name__ == "__main__":

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -17,6 +17,7 @@ python train.py \
     -proj test-model-compare
 """
 import argparse
+import json
 import os
 import pickle as pkl
 from glob import glob
@@ -658,21 +659,11 @@ def main():
         start_epoch, wts_fn = find_most_recent(args.model_o)
 
         # Load error dicts
-        if os.path.isfile(f"{args.model_o}/train_err.pkl"):
-            train_loss = pkl.load(open(f"{args.model_o}/train_err.pkl", "rb")).tolist()
+        if os.path.isfile(f"{args.model_o}/loss_dict.json"):
+            loss_dict = json.load(open(f"{args.model_o}/loss_dict.json"))
         else:
-            print("Couldn't find train loss file.", flush=True)
-            train_loss = None
-        if os.path.isfile(f"{args.model_o}/val_err.pkl"):
-            val_loss = pkl.load(open(f"{args.model_o}/val_err.pkl", "rb")).tolist()
-        else:
-            print("Couldn't find val loss file.", flush=True)
-            val_loss = None
-        if os.path.isfile(f"{args.model_o}/test_err.pkl"):
-            test_loss = pkl.load(open(f"{args.model_o}/test_err.pkl", "rb")).tolist()
-        else:
-            print("Couldn't find test loss file.", flush=True)
-            test_loss = None
+            print("Couldn't find loss dict file.", flush=True)
+            loss_dict = None
 
         # Need to add 1 to start_epoch bc the found idx is the last epoch
         #  successfully trained, not the one we want to start at
@@ -683,9 +674,7 @@ def main():
         else:
             wts_fn = None
         start_epoch = 0
-        train_loss = None
-        val_loss = None
-        test_loss = None
+        loss_dict = None
 
     # Load weights
     if wts_fn:
@@ -776,7 +765,7 @@ def main():
     os.makedirs(model_dir, exist_ok=True)
 
     # Train the model
-    model, train_loss, val_loss, test_loss = train(
+    model, loss_dict = train(
         model=model,
         ds_train=ds_train,
         ds_val=ds_val,
@@ -788,9 +777,7 @@ def main():
         save_file=model_dir,
         lr=args.lr,
         start_epoch=start_epoch,
-        train_loss=train_loss,
-        val_loss=val_loss,
-        test_loss=test_loss,
+        loss_dict=loss_dict,
         use_wandb=(args.wandb or args.sweep),
         batch_size=args.batch_size,
         es=es,

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -521,6 +521,12 @@ def init(args, rank=False):
         all_fns = []
         compounds = []
 
+    # Set cache_fn for GAT model if not already given
+    if (args.model.lower() == "gat") and (not args.cache):
+        cache_fn = os.path.join(model_dir, "graph.bin")
+    else:
+        cache_fn = args.cache
+
     # Load full dataset
     ds, exp_data = build_dataset(
         model_type=args.model,
@@ -528,7 +534,7 @@ def init(args, rank=False):
         all_fns=all_fns,
         compounds=compounds,
         achiral=args.achiral,
-        cache_fn=args.cache,
+        cache_fn=cache_fn,
         grouped=args.grouped,
         lig_name=args.n,
         num_workers=args.w,

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -150,6 +150,29 @@ def wandb_init(
     model_o=None,
     exp_configure=None,
 ):
+    """
+    Initialize WandB, handling saving the run ID (for continuing the run later).
+
+    Parameters
+    ----------
+    project_name : str
+        WandB project name
+    run_name : str
+        WandB run name
+    sweep : bool
+        Whether this is a sweep run (True) or regular training run (False)
+    cont : bool
+        Whether this run is a continuation of a previous run
+    model_o : str, optional
+        Output directory, necessary if continuing a run
+    exp_configure : dict
+        Dict passed for WandB config
+
+    Returns
+    -------
+    str
+        The WandB run ID for the initialized run
+    """
     import wandb
 
     if sweep:

--- a/asapdiscovery-ml/asapdiscovery/ml/utils.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/utils.py
@@ -1485,16 +1485,18 @@ def train(
     if use_wandb:
         import wandb
 
-    # Dicts of compounds (one for each split) storing true label and
-    #  preds/losses per epoch
-    # eg:
-    # loss_dict["train"][compound_id: str] = {
-    #     "target": float,  # exp label
-    #     "in_range": float,  # exp is in assay range
-    #     "uncertainty": float,  # measurement uncertainty
-    #     "preds": list[float],  # list of model predictions (per epoch)
-    #     "losses": list[float],  # list of losses (per epoch)
-    # }
+    """
+    Dicts of compounds (one for each split) storing true label and
+     preds/losses per epoch
+    eg:
+    loss_dict["train"][compound_id: str] = {
+        "target": float,  # exp label
+        "in_range": float,  # exp is in assay range
+        "uncertainty": float,  # measurement uncertainty
+        "preds": list[float],  # list of model predictions (per epoch)
+        "losses": list[float],  # list of losses (per epoch)
+    }
+    """
     if not loss_dict:
         loss_dict = {"train": {}, "val": {}, "test": {}}
 

--- a/asapdiscovery-ml/asapdiscovery/ml/utils.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/utils.py
@@ -710,6 +710,20 @@ def build_optimizer(model, config=None):
             weight_decay=weight_decay,
             dampening=dampening,
         )
+    elif optim_type == "adadelta":
+        optimizer = torch.optim.Adadelta(model.parameters(), lr=config["lr"])
+    elif optim_type == "adamw":
+        # Defaults from torch if not present in config
+        b1 = config["b1"] if "b1" in config else 0.9
+        b2 = config["b2"] if "b2" in config else 0.999
+        weight_decay = config["weight_decay"] if "weight_decay" in config else 0.01
+
+        optimizer = torch.optim.AdamW(
+            model.parameters(),
+            lr=config["lr"],
+            betas=(b1, b2),
+            weight_decay=weight_decay,
+        )
     else:
         raise ValueError(f"Unknown optimizer type: {optim_type}")
 


### PR DESCRIPTION
Redo of #406, should have all suggestions there addressed.

Change the stats that are tracked logged during training to include the compound and label associated with loss values, rather than just the loss values themselves. This will make it easier to figure out what's going on in training and isolate any specific molecules that might be difficult for the model.

Also some other minor changes that coincided with this, mainly a rearrangement of the code in train.py to be smarter about wandb initialization and letting it play better with CLI args.
