### PR TITLE
Fix for GIF viz so that pocket is coloured correctly

### DIFF
--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -186,7 +186,7 @@ class GIFVisualizer:
         # Select ligand and receptor
         p.cmd.select("ligand", "resn UNK")
         p.cmd.select(
-            "receptor", "chain A or chain B"
+            "receptor", "chain A or chain B or chain 1 or chain 2"
         )  # TODO: Modify this to generalize to dimer
         p.cmd.select(
             "binding_site", "name CA within 7 of resn UNK"

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -277,7 +277,7 @@ class VanillaMDSimulator:
                 output_topology,
                 output_positions[output_indices, :],
                 file=outfile,
-                keepIds=False,
+                keepIds=True,
             )
         return simulation, context
 
@@ -335,7 +335,7 @@ class VanillaMDSimulator:
                 output_topology,
                 output_positions[output_indices, :],
                 file=outfile,
-                keepIds=False,
+                keepIds=True,
             )
 
         # Flush trajectories to force files to be closed


### PR DESCRIPTION
Fixes #393 

Adds in `keepIds=True` so the right residue numbers are written to PDB files. 
