### PR TITLE
Don't log (potentially) confidential info

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -102,6 +102,8 @@ def make_wandb_table(ds_split):
             "crystal",
             "compound_id",
             "pIC50",
+            "pIC50_range",
+            "pIC50_stderr",
             "date_created",
         ]
     )
@@ -118,13 +120,23 @@ def make_wandb_table(ds_split):
             pic50 = tmp_d["pIC50"].item()
         except KeyError:
             pic50 = np.nan
+        try:
+            pic50_range = tmp_d["pIC50_range"].item()
+        except KeyError:
+            pic50_range = np.nan
+        try:
+            pic50_stderr = tmp_d["pIC50_stderr"].item()
+        except KeyError:
+            pic50_stderr = np.nan
         except AttributeError:
             pic50 = tmp_d["pIC50"]
         try:
             date_created = tmp_d["date_created"]
         except KeyError:
             date_created = None
-        table.add_data(xtal_id, compound_id, pic50, date_created)
+        table.add_data(
+            xtal_id, compound_id, pic50, pic50_range, pic50_stderr, date_created
+        )
 
     return table
 

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -96,16 +96,11 @@ def add_lig_labels(ds):
 
 def make_wandb_table(ds_split):
     import wandb
-    from rdkit.Chem import MolFromSmiles
-    from rdkit.Chem.AllChem import Compute2DCoords, GenerateDepictionMatching2DStructure
-    from rdkit.Chem.Draw import MolToImage
 
     table = wandb.Table(
         columns=[
             "crystal",
             "compound_id",
-            "molecule",
-            "smiles",
             "pIC50",
             "date_created",
         ]
@@ -120,15 +115,6 @@ def make_wandb_table(ds_split):
             compound_id = compound
             tmp_d = d[0]
         try:
-            smiles = tmp_d["smiles"]
-            mol = MolFromSmiles(smiles)
-            Compute2DCoords(mol)
-            GenerateDepictionMatching2DStructure(mol, mol)
-            mol = wandb.Image(MolToImage(mol, size=(300, 300)))
-        except (KeyError, ValueError):
-            smiles = ""
-            mol = None
-        try:
             pic50 = tmp_d["pic50"].item()
         except KeyError:
             pic50 = np.nan
@@ -138,7 +124,7 @@ def make_wandb_table(ds_split):
             date_created = tmp_d["date_created"]
         except KeyError:
             date_created = None
-        table.add_data(xtal_id, compound_id, mol, smiles, pic50, date_created)
+        table.add_data(xtal_id, compound_id, pic50, date_created)
 
     return table
 

--- a/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/scripts/train.py
@@ -115,11 +115,11 @@ def make_wandb_table(ds_split):
             compound_id = compound
             tmp_d = d[0]
         try:
-            pic50 = tmp_d["pic50"].item()
+            pic50 = tmp_d["pIC50"].item()
         except KeyError:
             pic50 = np.nan
         except AttributeError:
-            pic50 = tmp_d["pic50"]
+            pic50 = tmp_d["pIC50"]
         try:
             date_created = tmp_d["date_created"]
         except KeyError:


### PR DESCRIPTION
Previously we were logging SMILES and molecular structures to WandB during training runs, which might be an issue when/if we start working with P5 data. I also added logging for a couple other experimental values.