### PR TITLE
Make targets build from PDB strictly protein only.

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/target.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/target.py
@@ -4,12 +4,16 @@ from typing import Any, Dict, Optional, Tuple, Union  # noqa: F401
 from asapdiscovery.data.openeye import (
     bytes64_to_oedu,
     load_openeye_design_unit,
+    load_openeye_pdb,
     oechem,
     oedu_to_bytes64,
     oemol_to_pdb_string,
     pdb_string_to_oemol,
     save_openeye_design_unit,
 )
+from asapdiscovery.modeling.modeling import split_openeye_mol
+from asapdiscovery.modeling.schema import MoleculeFilter
+
 from asapdiscovery.data.postera.manifold_data_validation import TargetTags
 from pydantic import Field, root_validator
 
@@ -17,7 +21,6 @@ from .schema_base import (
     DataModelAbstractBase,
     DataStorageType,
     check_strings_for_equality_with_exclusion,
-    read_file_directly,
     schema_dict_get_val_overload,
     write_file_directly,
 )
@@ -91,34 +94,30 @@ class Target(DataModelAbstractBase):
 
     @classmethod
     def from_pdb(
-        cls, pdb_file: Union[str, Path], target_name: Optional[str] = None, **kwargs
+        cls, pdb_file: Union[str, Path], target_chains=[], ligand_chain="", **kwargs
     ) -> "Target":
+        kwargs.pop("data", None)
         # directly read in data
-        pdb_str = read_file_directly(pdb_file)
-        return cls(data=pdb_str, target_name=target_name, **kwargs)
+        # First load full complex molecule
+        complex_mol = load_openeye_pdb(pdb_file)
 
-    @classmethod
-    def from_pdb_via_openeye(
-        cls, pdb_file: Union[str, Path], target_name: Optional[str] = None, **kwargs
-    ) -> "Target":
-        # directly read in data
-        pdb_str = read_file_directly(pdb_file)
-        # NOTE: tradeof between speed and consistency with `from_pdb` method lines below will make sure that the pdb string is
-        # consistent between a load and dump by roundtripping through and openeye mol but will slow down the process significantly.
-        mol = pdb_string_to_oemol(pdb_str)
-        pdb_str = oemol_to_pdb_string(mol)
-        return cls(data=pdb_str, target_name=target_name, **kwargs)
+        # Split molecule into parts using given chains
+        mol_filter = MoleculeFilter(
+            protein_chains=target_chains, ligand_chain=ligand_chain
+        )
+        split_dict = split_openeye_mol(complex_mol, mol_filter)
+
+        return cls.from_oemol(split_dict["prot"], **kwargs)
 
     def to_pdb(self, filename: Union[str, Path]) -> None:
         # directly write out data
         write_file_directly(filename, self.data)
 
     @classmethod
-    def from_oemol(
-        cls, mol: oechem.OEMol, target_name: Optional[str] = None, **kwargs
-    ) -> "Target":
+    def from_oemol(cls, mol: oechem.OEMol, **kwargs) -> "Target":
+        kwargs.pop("data", None)
         pdb_str = oemol_to_pdb_string(mol)
-        return cls(data=pdb_str, target_name=target_name, **kwargs)
+        return cls(data=pdb_str, **kwargs)
 
     def to_oemol(self) -> oechem.OEMol:
         return pdb_string_to_oemol(self.data)
@@ -175,21 +174,19 @@ class PreppedTarget(DataModelAbstractBase):
         return v
 
     @classmethod
-    def from_oedu(
-        cls, oedu: oechem.OEDesignUnit, target_name: Optional[str] = None, **kwargs
-    ) -> "PreppedTarget":
+    def from_oedu(cls, oedu: oechem.OEDesignUnit, **kwargs) -> "PreppedTarget":
+        kwargs.pop("data", None)
         oedu_bytes = oedu_to_bytes64(oedu)
-        return cls(data=oedu_bytes, target_name=target_name, **kwargs)
+        return cls(data=oedu_bytes, **kwargs)
 
     def to_oedu(self) -> oechem.OEDesignUnit:
         return bytes64_to_oedu(self.data)
 
     @classmethod
-    def from_oedu_file(
-        cls, oedu_file: Union[str, Path], target_name: Optional[str] = None, **kwargs
-    ) -> "PreppedTarget":
+    def from_oedu_file(cls, oedu_file: Union[str, Path], **kwargs) -> "PreppedTarget":
+        kwargs.pop("data", None)
         oedu = load_openeye_design_unit(oedu_file)
-        return cls.from_oedu(oedu=oedu, target_name=target_name, **kwargs)
+        return cls.from_oedu(oedu=oedu, **kwargs)
 
     def to_oedu_file(self, filename: Union[str, Path]) -> None:
         oedu = self.to_oedu()

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/target.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/target.py
@@ -11,10 +11,9 @@ from asapdiscovery.data.openeye import (
     pdb_string_to_oemol,
     save_openeye_design_unit,
 )
+from asapdiscovery.data.postera.manifold_data_validation import TargetTags
 from asapdiscovery.modeling.modeling import split_openeye_mol
 from asapdiscovery.modeling.schema import MoleculeFilter
-
-from asapdiscovery.data.postera.manifold_data_validation import TargetTags
 from pydantic import Field, root_validator
 
 from .schema_base import (

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
@@ -76,7 +76,7 @@ def test_target_dict_roundtrip(
 ):
     t1 = Target.from_pdb(
         moonshot_pdb,
-        target_name,
+        target_name=target_name,
         ids=TargetIdentifiers(
             target_type=ttype, fragalysis_id=fragalysis_id, pdb_code=pdb_code
         ),
@@ -96,7 +96,7 @@ def test_target_json_roundtrip(
 ):
     t1 = Target.from_pdb(
         moonshot_pdb,
-        target_name,
+        target_name=target_name,
         ids=TargetIdentifiers(
             target_type=ttype, fragalysis_id=fragalysis_id, pdb_code=pdb_code
         ),
@@ -116,7 +116,7 @@ def test_target_json_file_roundtrip(
 ):
     t1 = Target.from_pdb(
         moonshot_pdb,
-        target_name,
+        target_name=target_name,
         ids=TargetIdentifiers(
             target_type=ttype, fragalysis_id=fragalysis_id, pdb_code=pdb_code
         ),
@@ -128,8 +128,8 @@ def test_target_json_file_roundtrip(
 
 
 def test_target_data_equal(moonshot_pdb):
-    t1 = Target.from_pdb(moonshot_pdb, "TargetTestName")
-    t2 = Target.from_pdb(moonshot_pdb, "TargetTestName")
+    t1 = Target.from_pdb(moonshot_pdb, target_name="TargetTestName")
+    t2 = Target.from_pdb(moonshot_pdb, target_name="TargetTestName")
     # does the same thing as the __eq__ method
     assert t1.data_equal(t2)
     assert t1 == t2
@@ -138,18 +138,18 @@ def test_target_data_equal(moonshot_pdb):
 def test_target_oemol_roundtrip(
     moonshot_pdb_processed,
 ):  # test that pre-processed pdb files can be read in and out consistently
-    t1 = Target.from_pdb(moonshot_pdb_processed, "TargetTestName")
+    t1 = Target.from_pdb(moonshot_pdb_processed, target_name="TargetTestName")
     mol = t1.to_oemol()
-    t2 = Target.from_oemol(mol, "TargetTestName")
+    t2 = Target.from_oemol(mol, target_name="TargetTestName")
     assert t1 == t2
 
 
 def test_target_oemol_roundtrip_sars2(
     sars2_spruced_pdb,
 ):  # test that a pdb file can be read in and out consistently via roundtrip through openeye
-    t1 = Target.from_pdb(sars2_spruced_pdb, "TargetTestName")
+    t1 = Target.from_pdb(sars2_spruced_pdb, target_name="TargetTestName")
     mol = t1.to_oemol()
-    t2 = Target.from_oemol(mol, "TargetTestName")
+    t2 = Target.from_oemol(mol, target_name="TargetTestName")
     assert t1 == t2
 
 
@@ -157,7 +157,7 @@ def test_target_oemol_roundtrip_sars2(
 
 
 def test_preppedtarget_from_oedu_file(oedu_file):
-    pt = PreppedTarget.from_oedu_file(oedu_file, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     oedu = pt.to_oedu()
     assert oedu.GetTitle() == "(AB) > LIG(A-403)"  # from one of the old files
 
@@ -176,37 +176,37 @@ def test_preppedtarget_from_oedu_file_at_least_one_target_id(oedu_file):
 def test_prepped_target_from_oedu_file_bad_file():
     with pytest.raises(FileNotFoundError):
         # neither id is set
-        _ = PreppedTarget.from_oedu_file("bad_file", "PreppedTargetTestName")
+        _ = PreppedTarget.from_oedu_file("bad_file", target_name="PreppedTargetTestName")
 
 
 def test_prepped_target_from_oedu(oedu_file):
     loaded_oedu = load_openeye_design_unit(oedu_file)
     loaded_oedu.SetTitle("PreppedTargetTestName")
-    pt = PreppedTarget.from_oedu(loaded_oedu, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu(loaded_oedu, target_name="PreppedTargetTestName")
     oedu = pt.to_oedu()
     assert oedu.GetTitle() == "PreppedTargetTestName"
 
 
 def test_prepped_target_from_oedu_file_roundtrip(oedu_file, tmp_path):
-    pt = PreppedTarget.from_oedu_file(oedu_file, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     pt.to_oedu_file(tmp_path / "test.oedu")
-    pt2 = PreppedTarget.from_oedu_file(tmp_path / "test.oedu", "PreppedTargetTestName")
+    pt2 = PreppedTarget.from_oedu_file(tmp_path / "test.oedu", target_name="PreppedTargetTestName")
     # these two comparisons should be the same
     assert pt == pt2
     assert pt.data_equal(pt2)
 
 
 def test_prepped_target_from_oedu_roundtrip(oedu_file):
-    pt = PreppedTarget.from_oedu_file(oedu_file, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     du = pt.to_oedu()
-    pt2 = PreppedTarget.from_oedu(du, "PreppedTargetTestName")
+    pt2 = PreppedTarget.from_oedu(du, target_name="PreppedTargetTestName")
     # these two comparisons should be the same
     assert pt == pt2
     assert pt.data_equal(pt2)
 
 
 def test_prepped_target_json_roundtrip(oedu_file):
-    pt = PreppedTarget.from_oedu_file(oedu_file, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     js = pt.json()
     pt2 = PreppedTarget.from_json(js)
     # these two comparisons should be the same
@@ -217,7 +217,7 @@ def test_prepped_target_json_roundtrip(oedu_file):
 
 
 def test_prepped_target_json_file_roundtrip(oedu_file, tmp_path):
-    pt = PreppedTarget.from_oedu_file(oedu_file, "PreppedTargetTestName")
+    pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     path = tmp_path / "test.json"
     pt.to_json_file(path)
     pt2 = PreppedTarget.from_json_file(path)

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
@@ -1,8 +1,5 @@
 import pytest
-from asapdiscovery.data.openeye import (
-    load_openeye_design_unit,
-    oechem
-)
+from asapdiscovery.data.openeye import load_openeye_design_unit, oechem
 from asapdiscovery.data.schema_v2.target import PreppedTarget, Target, TargetIdentifiers
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from pydantic import ValidationError

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
@@ -1,8 +1,7 @@
 import pytest
 from asapdiscovery.data.openeye import (
     load_openeye_design_unit,
-    oechem,
-    save_openeye_pdb,
+    oechem
 )
 from asapdiscovery.data.schema_v2.target import PreppedTarget, Target, TargetIdentifiers
 from asapdiscovery.data.testing.test_resources import fetch_test_file

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
@@ -1,5 +1,9 @@
 import pytest
-from asapdiscovery.data.openeye import oechem, load_openeye_design_unit, save_openeye_pdb
+from asapdiscovery.data.openeye import (
+    load_openeye_design_unit,
+    oechem,
+    save_openeye_pdb,
+)
 from asapdiscovery.data.schema_v2.target import PreppedTarget, Target, TargetIdentifiers
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from pydantic import ValidationError
@@ -164,9 +168,8 @@ def test_target_moonshot_pdb_processed_no_ligand(moonshot_pdb):
 
     oechem.OESplitMolComplex(lig, prot, wat, other, mol, opts)
     assert lig.NumAtoms() == 0
-    assert prot.NumAtoms() !=0
+    assert prot.NumAtoms() != 0
     assert wat.NumAtoms() == 0
-
 
 
 # PreppedTarget tests
@@ -192,7 +195,9 @@ def test_preppedtarget_from_oedu_file_at_least_one_target_id(oedu_file):
 def test_prepped_target_from_oedu_file_bad_file():
     with pytest.raises(FileNotFoundError):
         # neither id is set
-        _ = PreppedTarget.from_oedu_file("bad_file", target_name="PreppedTargetTestName")
+        _ = PreppedTarget.from_oedu_file(
+            "bad_file", target_name="PreppedTargetTestName"
+        )
 
 
 def test_prepped_target_from_oedu(oedu_file):
@@ -206,7 +211,9 @@ def test_prepped_target_from_oedu(oedu_file):
 def test_prepped_target_from_oedu_file_roundtrip(oedu_file, tmp_path):
     pt = PreppedTarget.from_oedu_file(oedu_file, target_name="PreppedTargetTestName")
     pt.to_oedu_file(tmp_path / "test.oedu")
-    pt2 = PreppedTarget.from_oedu_file(tmp_path / "test.oedu", target_name="PreppedTargetTestName")
+    pt2 = PreppedTarget.from_oedu_file(
+        tmp_path / "test.oedu", target_name="PreppedTargetTestName"
+    )
     # these two comparisons should be the same
     assert pt == pt2
     assert pt.data_equal(pt2)

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_target_schema_v2.py
@@ -1,5 +1,5 @@
 import pytest
-from asapdiscovery.data.openeye import load_openeye_design_unit
+from asapdiscovery.data.openeye import oechem, load_openeye_design_unit, save_openeye_pdb
 from asapdiscovery.data.schema_v2.target import PreppedTarget, Target, TargetIdentifiers
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from pydantic import ValidationError
@@ -151,6 +151,22 @@ def test_target_oemol_roundtrip_sars2(
     mol = t1.to_oemol()
     t2 = Target.from_oemol(mol, target_name="TargetTestName")
     assert t1 == t2
+
+
+def test_target_moonshot_pdb_processed_no_ligand(moonshot_pdb):
+    t1 = Target.from_pdb(moonshot_pdb, target_name="TargetTestName")
+    mol = t1.to_oemol()
+    opts = oechem.OESplitMolComplexOptions()
+    lig = oechem.OEGraphMol()
+    prot = oechem.OEGraphMol()
+    wat = oechem.OEGraphMol()
+    other = oechem.OEGraphMol()
+
+    oechem.OESplitMolComplex(lig, prot, wat, other, mol, opts)
+    assert lig.NumAtoms() == 0
+    assert prot.NumAtoms() !=0
+    assert wat.NumAtoms() == 0
+
 
 
 # PreppedTarget tests


### PR DESCRIPTION
Fixes #434

Target schema built directly from a PDB should exclude the ligand, instead this is handled by a `Ligand` and combined in a Complex