### PR TITLE
Pull errors and tracebacks from errored tasks from alchemiscale

### DIFF
--- a/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
@@ -29,11 +29,10 @@ def validate_traceback_flag(ctx, param, value):
     default=False,
     help="Output the tracebacks from the failing tasks. Only usable in conjunction with --errors.",
     callback=validate_traceback_flag,
-    is_eager=True,
 )
 def status(network: str, errors: bool, with_traceback: bool):
     """
-    Get the status of the submitted network on alchemiscale.
+    Get the status of the submitted network on alchemiscale.\f
 
     Args:
         network: The name of the JSON file containing the FreeEnergyCalculationNetwork we should check the status of.

--- a/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
@@ -17,8 +17,20 @@ def validate_traceback_flag(ctx, param, value):
     default="planned_network.json",
     show_default=True,
 )
-@click.option("--errors", is_flag=True, default=False, help="Output errors from the network, if any.")
-@click.option("--with-traceback", is_flag=True, default=False, help="Output the tracebacks from the failing tasks. Only usable in conjunction with --errors.", callback=validate_traceback_flag, is_eager=True)
+@click.option(
+    "--errors",
+    is_flag=True,
+    default=False,
+    help="Output errors from the network, if any.",
+)
+@click.option(
+    "--with-traceback",
+    is_flag=True,
+    default=False,
+    help="Output the tracebacks from the failing tasks. Only usable in conjunction with --errors.",
+    callback=validate_traceback_flag,
+    is_eager=True,
+)
 def status(network: str, errors: bool, with_traceback: bool):
     """
     Get the status of the submitted network on alchemiscale.
@@ -40,6 +52,7 @@ def status(network: str, errors: bool, with_traceback: bool):
     client.network_status(planned_network=planned_network)
     # Output errors
     if errors:
-        task_errors = client.collect_errors(planned_network, with_traceback=with_traceback)
+        task_errors = client.collect_errors(
+            planned_network, with_traceback=with_traceback
+        )
         print(task_errors)
-

--- a/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/cli/status.py
@@ -1,4 +1,6 @@
+import json
 import click
+
 
 
 def validate_traceback_flag(ctx, param, value):
@@ -54,4 +56,4 @@ def status(network: str, errors: bool, with_traceback: bool):
         task_errors = client.collect_errors(
             planned_network, with_traceback=with_traceback
         )
-        print(task_errors)
+        print(json.dumps(task_errors, indent=4))

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
@@ -1,7 +1,10 @@
+import datetime
 import openfe
 import pytest
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from asapdiscovery.simulation.schema.fec import FreeEnergyCalculationNetwork
+from asapdiscovery.simulation.utils import AlchemiscaleHelper
+from gufe.protocols.protocolunit import ProtocolUnit, Context, ProtocolUnitFailure
 from rdkit import Chem
 
 
@@ -27,3 +30,50 @@ def tyk2_fec_network():
     """Create a FEC planned network from file"""
     fec_network = fetch_test_file("tyk2_small_network.json")
     return FreeEnergyCalculationNetwork.from_file(fec_network)
+
+
+@pytest.fixture()
+def mock_alchemiscale_client(monkeypatch):
+    """Mock alchemiscale client for testing purposes"""
+    # mock some env variables
+    monkeypatch.setenv(name="ALCHEMISCALE_ID", value="asap")
+    monkeypatch.setenv(name="ALCHEMISCALE_KEY", value="key")
+
+    # use a fake api url for testing
+    client = AlchemiscaleHelper(api_url="")
+
+    return client
+
+
+# Gufe fixtures for mocking purposes
+
+@pytest.fixture
+class DummyUnit(ProtocolUnit):
+    @staticmethod
+    def _execute(ctx: Context, an_input=2, **inputs):
+        if an_input != 2:
+            raise ValueError("`an_input` should always be 2(!!!)")
+
+        return {"foo": "bar"}
+
+
+@pytest.fixture
+def dummy_protocol_units() -> list[ProtocolUnit]:
+    """Create list of 3 Dummy protocol units"""
+    units = [DummyUnit(name=f"dummy{i}") for i in range(3)]
+    return units
+
+
+@pytest.fixture()
+def protocol_unit_failures(dummy_protocol_units) -> list[list[ProtocolUnitFailure]]:
+    """generate 2 unit failures for every task"""
+    t1 = datetime.datetime.now()
+    t2 = datetime.datetime.now()
+
+    return [[ProtocolUnitFailure(source_key=u.key, inputs=u.inputs,
+                                 outputs=dict(),
+                                 exception=('ValueError', "Didn't feel like it"),
+                                 traceback='foo',
+                                 start_time=t1, end_time=t2)
+             for _ in range(2)]
+            for u in dummy_protocol_units]

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
@@ -1,10 +1,11 @@
 import datetime
+
 import openfe
 import pytest
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from asapdiscovery.simulation.schema.fec import FreeEnergyCalculationNetwork
 from asapdiscovery.simulation.utils import AlchemiscaleHelper
-from gufe.protocols.protocolunit import ProtocolUnit, Context, ProtocolUnitFailure
+from gufe.protocols.protocolunit import Context, ProtocolUnit, ProtocolUnitFailure
 from rdkit import Chem
 
 
@@ -47,6 +48,7 @@ def mock_alchemiscale_client(monkeypatch):
 
 # Gufe fixtures for mocking purposes
 
+
 @pytest.fixture
 class DummyUnit(ProtocolUnit):
     @staticmethod
@@ -70,10 +72,18 @@ def protocol_unit_failures(dummy_protocol_units) -> list[list[ProtocolUnitFailur
     t1 = datetime.datetime.now()
     t2 = datetime.datetime.now()
 
-    return [[ProtocolUnitFailure(source_key=u.key, inputs=u.inputs,
-                                 outputs=dict(),
-                                 exception=('ValueError', "Didn't feel like it"),
-                                 traceback='foo',
-                                 start_time=t1, end_time=t2)
-             for _ in range(2)]
-            for u in dummy_protocol_units]
+    return [
+        [
+            ProtocolUnitFailure(
+                source_key=u.key,
+                inputs=u.inputs,
+                outputs=dict(),
+                exception=("ValueError", "Didn't feel like it"),
+                traceback="foo",
+                start_time=t1,
+                end_time=t2,
+            )
+            for _ in range(2)
+        ]
+        for u in dummy_protocol_units
+    ]

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/conftest.py
@@ -1,11 +1,8 @@
-import datetime
-
 import openfe
 import pytest
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from asapdiscovery.simulation.schema.fec import FreeEnergyCalculationNetwork
 from asapdiscovery.simulation.utils import AlchemiscaleHelper
-from gufe.protocols.protocolunit import Context, ProtocolUnit, ProtocolUnitFailure
 from rdkit import Chem
 
 
@@ -44,46 +41,3 @@ def mock_alchemiscale_client(monkeypatch):
     client = AlchemiscaleHelper(api_url="")
 
     return client
-
-
-# Gufe fixtures for mocking purposes
-
-
-@pytest.fixture
-class DummyUnit(ProtocolUnit):
-    @staticmethod
-    def _execute(ctx: Context, an_input=2, **inputs):
-        if an_input != 2:
-            raise ValueError("`an_input` should always be 2(!!!)")
-
-        return {"foo": "bar"}
-
-
-@pytest.fixture
-def dummy_protocol_units() -> list[ProtocolUnit]:
-    """Create list of 3 Dummy protocol units"""
-    units = [DummyUnit(name=f"dummy{i}") for i in range(3)]
-    return units
-
-
-@pytest.fixture()
-def protocol_unit_failures(dummy_protocol_units) -> list[list[ProtocolUnitFailure]]:
-    """generate 2 unit failures for every task"""
-    t1 = datetime.datetime.now()
-    t2 = datetime.datetime.now()
-
-    return [
-        [
-            ProtocolUnitFailure(
-                source_key=u.key,
-                inputs=u.inputs,
-                outputs=dict(),
-                exception=("ValueError", "Didn't feel like it"),
-                traceback="foo",
-                start_time=t1,
-                end_time=t2,
-            )
-            for _ in range(2)
-        ]
-        for u in dummy_protocol_units
-    ]

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -1,10 +1,11 @@
 import itertools
+
 from alchemiscale import Scope, ScopedKey
 from asapdiscovery.simulation.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from gufe.protocols import ProtocolUnitResult, ProtocolDAGResult, ProtocolUnitFailure
+from gufe.protocols import ProtocolDAGResult, ProtocolUnitFailure, ProtocolUnitResult
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
 
@@ -171,7 +172,13 @@ def test_collect_results(monkeypatch, tyk2_fec_network, mock_alchemiscale_client
     )  # divide by 2 as we have a node for the solvent and complex phase
 
 
-def test_get_failures(monkeypatch, tyk2_fec_network, mock_alchemiscale_client, dummy_protocol_units, protocol_unit_failures):
+def test_get_failures(
+    monkeypatch,
+    tyk2_fec_network,
+    mock_alchemiscale_client,
+    dummy_protocol_units,
+    protocol_unit_failures,
+):
     """Make sure we can get exceptions and tracebacks from failures in a task"""
 
     # use a fake api url for testing

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -1,13 +1,55 @@
+import datetime
 import itertools
+import pytest
 
 from alchemiscale import Scope, ScopedKey
 from asapdiscovery.simulation.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from gufe.protocols import ProtocolDAGResult, ProtocolUnitResult
+from gufe.protocols import ProtocolUnitResult, ProtocolDAGResult, ProtocolUnit, ProtocolUnitFailure, Context
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
+
+
+# Test gufe "fixtures"
+class DummyUnit(ProtocolUnit):
+    @staticmethod
+    def _execute(ctx: Context, an_input=2, **inputs):
+        if an_input != 2:
+            raise ValueError("`an_input` should always be 2(!!!)")
+
+        return {"foo": "bar"}
+
+
+@pytest.fixture
+def dummy_protocol_units() -> list[ProtocolUnit]:
+    """Create list of 3 Dummy protocol units"""
+    units = [DummyUnit(name=f"dummy{i}") for i in range(3)]
+    return units
+
+
+@pytest.fixture()
+def protocol_unit_failures(dummy_protocol_units) -> list[list[ProtocolUnitFailure]]:
+    """generate 2 unit failures for every task"""
+    t1 = datetime.datetime.now()
+    t2 = datetime.datetime.now()
+
+    return [
+        [
+            ProtocolUnitFailure(
+                source_key=u.key,
+                inputs=u.inputs,
+                outputs=dict(),
+                exception=("ValueError", "Didn't feel like it"),
+                traceback="foo",
+                start_time=t1,
+                end_time=t2,
+            )
+            for _ in range(2)
+        ]
+        for u in dummy_protocol_units
+    ]
 
 
 def test_create_network(monkeypatch, tyk2_fec_network, mock_alchemiscale_client):
@@ -179,7 +221,7 @@ def test_get_failures(
     dummy_protocol_units,
     protocol_unit_failures,
 ):
-    """Make sure we can get exceptions and tracebacks from failures in a task"""
+    """Make sure we can get exceptions and tracebacks from failures in a network"""
 
     # use a fake api url for testing
     client = mock_alchemiscale_client

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -1,13 +1,19 @@
 import datetime
 import itertools
-import pytest
 
+import pytest
 from alchemiscale import Scope, ScopedKey
 from asapdiscovery.simulation.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from gufe.protocols import ProtocolUnitResult, ProtocolDAGResult, ProtocolUnit, ProtocolUnitFailure, Context
+from gufe.protocols import (
+    Context,
+    ProtocolDAGResult,
+    ProtocolUnit,
+    ProtocolUnitFailure,
+    ProtocolUnitResult,
+)
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
 
@@ -271,4 +277,6 @@ def test_get_failures(
     # With complete traceback
     errors = client.collect_errors(planned_network=result_network, with_traceback=True)
     assert n_errors == 18, f"Expected 18 errors, received {n_errors} errors."
-    assert all("traceback" in data.keys() for data in errors.values()), "`traceback` key expected and not found in results dictionary."
+    assert all(
+        "traceback" in data.keys() for data in errors.values()
+    ), "`traceback` key expected and not found in results dictionary."

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -5,7 +5,7 @@ from asapdiscovery.simulation.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from gufe.protocols import ProtocolDAGResult, ProtocolUnitFailure, ProtocolUnitResult
+from gufe.protocols import ProtocolUnitResult, ProtocolDAGResult
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
 

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -264,7 +264,11 @@ def test_get_failures(
     monkeypatch.setattr(client._client, "get_task_failures", get_task_failures)
 
     # Collect errors without traceback
-    errors = client.collect_errors(planned_network=result_network, traceback=False)
+    errors = client.collect_errors(planned_network=result_network, with_traceback=False)
+    n_errors = len(errors)
+    assert n_errors == 18, f"Expected 18 errors, received {n_errors} errors."
 
     # With complete traceback
-    errors = client.collect_errors(planned_network=result_network, traceback=True)
+    errors = client.collect_errors(planned_network=result_network, with_traceback=True)
+    assert n_errors == 18, f"Expected 18 errors, received {n_errors} errors."
+    assert all("traceback" in data.keys() for data in errors.values()), "`traceback` key expected and not found in results dictionary."

--- a/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/tests/test_utils.py
@@ -5,7 +5,7 @@ from asapdiscovery.simulation.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from gufe.protocols import ProtocolUnitResult, ProtocolDAGResult
+from gufe.protocols import ProtocolDAGResult, ProtocolUnitResult
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
 

--- a/asapdiscovery-simulation/asapdiscovery/simulation/utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/utils.py
@@ -177,7 +177,11 @@ class AlchemiscaleHelper:
 
         return network_with_results
 
-    def collect_errors(self, planned_network: FreeEnergyCalculationNetwork, with_traceback: bool = False) -> dict[str, dict[str, str]]:
+    def collect_errors(
+        self,
+        planned_network: FreeEnergyCalculationNetwork,
+        with_traceback: bool = False,
+    ) -> dict[str, dict[str, str]]:
         """
         Collect errors from failed tasks.
 

--- a/asapdiscovery-simulation/asapdiscovery/simulation/utils.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/utils.py
@@ -1,3 +1,5 @@
+import itertools
+from collections import defaultdict
 from typing import Optional
 
 from alchemiscale import Scope, ScopedKey
@@ -127,7 +129,7 @@ class AlchemiscaleHelper:
         Collect the results for the given network.
 
         Args:
-            planned_network: The network who's results we should collect.
+            planned_network: The network whose results we should collect.
 
         Returns:
             A FreeEnergyCalculationNetwork with all current results. If any are missing and allow missing is false an error is raised.
@@ -174,3 +176,26 @@ class AlchemiscaleHelper:
         )
 
         return network_with_results
+
+    def collect_errors(self, planned_network: FreeEnergyCalculationNetwork, with_traceback: bool = False) -> dict[str, dict[str, str]]:
+        """
+        Collect errors from failed tasks.
+
+        Args:
+            planned_network: Network to get failed tasks from.
+            with_traceback: Output the complete traceback for the failed tasks.
+
+        Returns:
+            Nested dictionary with task key as value and a dictionary with errors and tracebacks as values.
+        """
+        network_key = planned_network.results.network_key
+        errored_tasks = self._client.get_network_tasks(network_key, status="error")
+
+        error_data = defaultdict(dict)
+        for task in errored_tasks:
+            for err_result in self._client.get_task_failures(task):
+                for failure in err_result.protocol_unit_failures:
+                    error_data[str(task.gufe_key)]["errors"] = failure.exception
+                    if with_traceback:
+                        error_data[str(task.gufe_key)]["traceback"] = failure.traceback
+        return dict(error_data)


### PR DESCRIPTION
## Description
Add feature to extract errors and tracebacks from simulations run with alchemiscale.

The idea is to extend the `status` command to query the errored tasks in the network and return their key with the error (python exception) and the traceback, if specified in the CLI.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] Extend the `status` command with options or flags to get errors and tracebacks
  - [ ] Add the API point for this purpose in `AlchemiscaleHelper` class
  - [ ] Write tests

## Status
- [ ] Ready to go
