### PR TITLE
Fix Ligand equality checking

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -190,7 +190,7 @@ def test_fec_dataset_duplicate_ligands(tyk2_ligands, tyk2_protein):
 
     factory = FreeEnergyCalculationFactory()
     with pytest.raises(ValueError, match="1 duplicate ligands"):
-        planned_network = factory.create_fec_dataset(
+        _ = factory.create_fec_dataset(
             dataset_name="TYK2-test-dataset-duplicated",
             receptor=tyk2_protein,
             ligands=ligands,
@@ -200,7 +200,7 @@ def test_fec_dataset_duplicate_ligands(tyk2_ligands, tyk2_protein):
 
     factory = FreeEnergyCalculationFactory()
     with pytest.raises(ValueError, match="2 duplicate ligands"):
-        planned_network = factory.create_fec_dataset(
+        _ = factory.create_fec_dataset(
             dataset_name="TYK2-test-dataset-duplicated",
             receptor=tyk2_protein,
             ligands=ligands,

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_fec_schema.py
@@ -190,7 +190,7 @@ def test_fec_dataset_duplicate_ligands(tyk2_ligands, tyk2_protein):
 
     factory = FreeEnergyCalculationFactory()
     with pytest.raises(ValueError, match="1 duplicate ligands"):
-        _ = factory.create_fec_dataset(
+        planned_network = factory.create_fec_dataset(
             dataset_name="TYK2-test-dataset-duplicated",
             receptor=tyk2_protein,
             ligands=ligands,
@@ -200,7 +200,7 @@ def test_fec_dataset_duplicate_ligands(tyk2_ligands, tyk2_protein):
 
     factory = FreeEnergyCalculationFactory()
     with pytest.raises(ValueError, match="2 duplicate ligands"):
-        _ = factory.create_fec_dataset(
+        planned_network = factory.create_fec_dataset(
             dataset_name="TYK2-test-dataset-duplicated",
             receptor=tyk2_protein,
             ligands=ligands,

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union  # noqa: F401
 from uuid import UUID
@@ -152,6 +154,13 @@ class Ligand(DataModelAbstractBase):
             if k in reser_attr_names:
                 raise ValueError(f"Tag name {k} is a reserved attribute name")
         return v
+
+    def __eq__(self, other: Ligand) -> bool:
+        # Take out the header block since those aren't really important in checking
+        # equality
+        return "\n".join(self.data.split("\n")[2:]) == "\n".join(
+            other.data.split("\n")[2:]
+        )
 
     @classmethod
     def from_oemol(

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Union  # noqa: F401
 from uuid import UUID
@@ -155,7 +153,7 @@ class Ligand(DataModelAbstractBase):
                 raise ValueError(f"Tag name {k} is a reserved attribute name")
         return v
 
-    def __eq__(self, other: Ligand) -> bool:
+    def __eq__(self, other: "Ligand") -> bool:
         # Take out the header block since those aren't really important in checking
         # equality
         return "\n".join(self.data.split("\n")[2:]) == "\n".join(

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -154,6 +154,9 @@ class Ligand(DataModelAbstractBase):
         return v
 
     def __eq__(self, other: "Ligand") -> bool:
+        return self.data_equal(other)
+
+    def data_equal(self, other: "Ligand") -> bool:
         # Take out the header block since those aren't really important in checking
         # equality
         return "\n".join(self.data.split("\n")[2:]) == "\n".join(

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -51,9 +51,7 @@ class LigandIdentifiers(DataModelAbstractBase):
         Unique ID for P5 compchem reference, unused for now, by default None
     """
 
-    moonshot_compound_id: str | None = Field(
-        None, description="Moonshot compound ID"
-    )
+    moonshot_compound_id: str | None = Field(None, description="Moonshot compound ID")
     manifold_api_id: UUID | None = Field(
         None, description="Unique ID from Postera Manifold API"
     )

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -51,16 +51,16 @@ class LigandIdentifiers(DataModelAbstractBase):
         Unique ID for P5 compchem reference, unused for now, by default None
     """
 
-    moonshot_compound_id: str | None = Field(
+    moonshot_compound_id: Optional[str] = Field(
         None, description="Moonshot compound ID"
     )
-    manifold_api_id: UUID | None = Field(
+    manifold_api_id: Optional[UUID] = Field(
         None, description="Unique ID from Postera Manifold API"
     )
-    manifold_vc_id: str | None = Field(
+    manifold_vc_id: Optional[str] = Field(
         None, description="Unique VC ID (virtual compound ID) from Postera Manifold"
     )
-    compchem_id: UUID4 | None = Field(
+    compchem_id: Optional[UUID4] = Field(
         None, description="Unique ID for P5 compchem reference, unused for now"
     )
 
@@ -102,11 +102,11 @@ class Ligand(DataModelAbstractBase):
     """
 
     compound_name: str = Field(None, description="Name of compound")
-    ids: LigandIdentifiers | None = Field(
+    ids: Optional[LigandIdentifiers] = Field(
         None,
         description="LigandIdentifiers Schema for identifiers associated with this ligand",
     )
-    experimental_data: ExperimentalCompoundData | None = Field(
+    experimental_data: Optional[ExperimentalCompoundData] = Field(
         None,
         description="ExperimentalCompoundData Schema for experimental data associated with the compound",
     )
@@ -164,8 +164,8 @@ class Ligand(DataModelAbstractBase):
 
     @classmethod
     def from_oemol(
-        cls, mol: oechem.OEMol, compound_name: str | None = None, **kwargs
-    ) -> Ligand:
+        cls, mol: oechem.OEMol, compound_name: Optional[str] = None, **kwargs
+    ) -> "Ligand":
         """
         Create a Ligand from an OEMol
         """
@@ -181,8 +181,8 @@ class Ligand(DataModelAbstractBase):
 
     @classmethod
     def from_smiles(
-        cls, smiles: str, compound_name: str | None = None, **kwargs
-    ) -> Ligand:
+        cls, smiles: str, compound_name: Optional[str] = None, **kwargs
+    ) -> "Ligand":
         """
         Create a Ligand from a SMILES string
         """
@@ -217,11 +217,11 @@ class Ligand(DataModelAbstractBase):
     @classmethod
     def from_sdf(
         cls,
-        sdf_file: str | Path,
-        compound_name: str | None = None,
+        sdf_file: Union[str, Path],
+        compound_name: Optional[str] = None,
         read_SD_attrs: bool = True,
         **kwargs,
-    ) -> Ligand:
+    ) -> "Ligand":
         """
         Read in a ligand from an SDF file.
         If read_SD_attrs is True, then SD tags will be read in as attributes, overriding kwargs where double defined.
@@ -250,7 +250,7 @@ class Ligand(DataModelAbstractBase):
         lig.validate(lig.dict())
         return lig
 
-    def to_sdf(self, filename: str | Path, write_SD_attrs: bool = True) -> None:
+    def to_sdf(self, filename: Union[str, Path], write_SD_attrs: bool = True) -> None:
         """
         Write out the ligand to an SDF file
         If write_SD_attrs is True, then SD tags will be written out as attributes
@@ -367,4 +367,4 @@ class Ligand(DataModelAbstractBase):
 
 
 class ReferenceLigand(Ligand):
-    target_name: str | None = None
+    target_name: Optional[str] = None

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -51,7 +51,9 @@ class LigandIdentifiers(DataModelAbstractBase):
         Unique ID for P5 compchem reference, unused for now, by default None
     """
 
-    moonshot_compound_id: str | None = Field(None, description="Moonshot compound ID")
+    moonshot_compound_id: str | None = Field(
+        None, description="Moonshot compound ID"
+    )
     manifold_api_id: UUID | None = Field(
         None, description="Unique ID from Postera Manifold API"
     )

--- a/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema_v2/ligand.py
@@ -51,16 +51,16 @@ class LigandIdentifiers(DataModelAbstractBase):
         Unique ID for P5 compchem reference, unused for now, by default None
     """
 
-    moonshot_compound_id: Optional[str] = Field(
+    moonshot_compound_id: str | None = Field(
         None, description="Moonshot compound ID"
     )
-    manifold_api_id: Optional[UUID] = Field(
+    manifold_api_id: UUID | None = Field(
         None, description="Unique ID from Postera Manifold API"
     )
-    manifold_vc_id: Optional[str] = Field(
+    manifold_vc_id: str | None = Field(
         None, description="Unique VC ID (virtual compound ID) from Postera Manifold"
     )
-    compchem_id: Optional[UUID4] = Field(
+    compchem_id: UUID4 | None = Field(
         None, description="Unique ID for P5 compchem reference, unused for now"
     )
 
@@ -102,11 +102,11 @@ class Ligand(DataModelAbstractBase):
     """
 
     compound_name: str = Field(None, description="Name of compound")
-    ids: Optional[LigandIdentifiers] = Field(
+    ids: LigandIdentifiers | None = Field(
         None,
         description="LigandIdentifiers Schema for identifiers associated with this ligand",
     )
-    experimental_data: Optional[ExperimentalCompoundData] = Field(
+    experimental_data: ExperimentalCompoundData | None = Field(
         None,
         description="ExperimentalCompoundData Schema for experimental data associated with the compound",
     )
@@ -164,8 +164,8 @@ class Ligand(DataModelAbstractBase):
 
     @classmethod
     def from_oemol(
-        cls, mol: oechem.OEMol, compound_name: Optional[str] = None, **kwargs
-    ) -> "Ligand":
+        cls, mol: oechem.OEMol, compound_name: str | None = None, **kwargs
+    ) -> Ligand:
         """
         Create a Ligand from an OEMol
         """
@@ -181,8 +181,8 @@ class Ligand(DataModelAbstractBase):
 
     @classmethod
     def from_smiles(
-        cls, smiles: str, compound_name: Optional[str] = None, **kwargs
-    ) -> "Ligand":
+        cls, smiles: str, compound_name: str | None = None, **kwargs
+    ) -> Ligand:
         """
         Create a Ligand from a SMILES string
         """
@@ -217,11 +217,11 @@ class Ligand(DataModelAbstractBase):
     @classmethod
     def from_sdf(
         cls,
-        sdf_file: Union[str, Path],
-        compound_name: Optional[str] = None,
+        sdf_file: str | Path,
+        compound_name: str | None = None,
         read_SD_attrs: bool = True,
         **kwargs,
-    ) -> "Ligand":
+    ) -> Ligand:
         """
         Read in a ligand from an SDF file.
         If read_SD_attrs is True, then SD tags will be read in as attributes, overriding kwargs where double defined.
@@ -250,7 +250,7 @@ class Ligand(DataModelAbstractBase):
         lig.validate(lig.dict())
         return lig
 
-    def to_sdf(self, filename: Union[str, Path], write_SD_attrs: bool = True) -> None:
+    def to_sdf(self, filename: str | Path, write_SD_attrs: bool = True) -> None:
         """
         Write out the ligand to an SDF file
         If write_SD_attrs is True, then SD tags will be written out as attributes
@@ -367,4 +367,4 @@ class Ligand(DataModelAbstractBase):
 
 
 class ReferenceLigand(Ligand):
-    target_name: Optional[str] = None
+    target_name: str | None = None


### PR DESCRIPTION
Update `Ligand` `__eq__` method to exclude SDF header lines. Should fix #463 