### PR TITLE
make into local import

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli.py
@@ -167,7 +167,7 @@ def submit(network: str, organization: str, campaign: str, project: str):
     from alchemiscale import Scope
 
     from .schema.fec import FreeEnergyCalculationNetwork
-    from .simulation.utils import AlchemiscaleHelper
+    from .utils import AlchemiscaleHelper
 
     # launch the helper which will try to login
     click.echo("Connecting to Alchemiscale...")


### PR DESCRIPTION
wasn't able to run `asap-alchemy submit` on `main`, returned this error:

```
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/bin/asap-alchemy", line 8, in <module>
    sys.exit(cli())
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/lib/python3.10/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/lib/python3.10/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/lib/python3.10/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/lib/python3.10/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/homebrew/Caskroom/miniconda/base/envs/asapdiscovery/lib/python3.10/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/Users/jenkescheen/asapdiscovery/asapdiscovery-alchemy/asapdiscovery/alchemy/cli.py", line 170, in submit
    from .simulation.utils import AlchemiscaleHelper
ModuleNotFoundError: No module named 'asapdiscovery.alchemy.simulation'
```
I'm guessing this happened in https://github.com/choderalab/asapdiscovery/pull/471. This PR fixes the import.