### PR TITLE
Separate workflows/CI for subpackages

### DIFF
--- a/.github/workflows/alchemy.yaml
+++ b/.github/workflows/alchemy.yaml
@@ -1,0 +1,99 @@
+name: alchemy-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-alchemy --no-deps
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-alchemy \
+                       asapdiscovery-alchemy/asapdiscovery/alchemy/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -1,0 +1,98 @@
+name: data-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-data \
+                       asapdiscovery-data/asapdiscovery/data/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/dataviz.yaml
+++ b/.github/workflows/dataviz.yaml
@@ -1,0 +1,98 @@
+name: dataviz-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-dataviz \
+                       asapdiscovery-dataviz/asapdiscovery/dataviz/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -68,6 +68,7 @@ jobs:
       run: |
         python -m pip install -e ./asapdiscovery-data --no-deps
         python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
         micromamba list
 
     - name: Run tests

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-docking \
+                       asapdiscovery-docking/asapdiscovery/docking/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: docking-ci
 
 on:
   push:

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -67,7 +67,9 @@ jobs:
     - name: Install packages
       run: |
         python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
         python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
         python -m pip install -e ./asapdiscovery-modeling --no-deps
         micromamba list
 

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -71,6 +71,7 @@ jobs:
         python -m pip install -e ./asapdiscovery-docking --no-deps
         python -m pip install -e ./asapdiscovery-ml --no-deps
         python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
         micromamba list
 
     - name: Run tests

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -66,6 +66,7 @@ jobs:
 
     - name: Install packages
       run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
         python -m pip install -e ./asapdiscovery-docking --no-deps
         micromamba list
 

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ["3.9.2", "3.10"]
 
     env:

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: macos-CI
 
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [macOS-latest]
         python-version: ["3.9.2", "3.10"]
 
     env:

--- a/.github/workflows/ml.yaml
+++ b/.github/workflows/ml.yaml
@@ -1,0 +1,98 @@
+name: ml-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-ml \
+                       asapdiscovery-ml/asapdiscovery/ml/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/modeling.yaml
+++ b/.github/workflows/modeling.yaml
@@ -1,0 +1,98 @@
+name: modeling-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-modeling \
+                       asapdiscovery-modeling/asapdiscovery/modeling/test
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false

--- a/.github/workflows/modeling.yaml
+++ b/.github/workflows/modeling.yaml
@@ -84,7 +84,7 @@ jobs:
         set -e
         pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
                        --cov=asapdiscovery-modeling \
-                       asapdiscovery-modeling/asapdiscovery/modeling/test
+                       asapdiscovery-modeling/asapdiscovery/modeling/tests
 
     - name: Upload Code Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/modeling.yaml
+++ b/.github/workflows/modeling.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ["3.9.2", "3.10"]
 
     env:

--- a/.github/workflows/simulation.yaml
+++ b/.github/workflows/simulation.yaml
@@ -1,0 +1,98 @@
+name: simulation-ci
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "main"
+  schedule:
+    # Nightly tests run on main by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9.2", "3.10"]
+
+    env:
+      OE_LICENSE: ${{ github.workspace }}/oe_license.txt
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Get Info About Runner
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/mamba-org/provision-with-micromamba
+    - name: Setup Conda Environment
+      uses: mamba-org/setup-micromamba@v1
+      with:
+        environment-file: devtools/conda-envs/asapdiscovery-${{ matrix.os }}.yml
+        environment-name: asapdiscovery
+        cache-environment: true
+        cache-downloads: true
+        create-args: >-
+          python==${{ matrix.python-version }}
+
+    - name: Test OE License & Write License to File
+      env:
+        OE_LICENSE_TEXT: ${{ secrets.OE_LICENSE }}
+      run: |
+        echo "${OE_LICENSE_TEXT}" > ${OE_LICENSE}
+        python -c "import openeye; assert openeye.oechem.OEChemIsLicensed(), 'OpenEye license checks failed!'"
+
+    - name: Install packages
+      run: |
+        python -m pip install -e ./asapdiscovery-data --no-deps
+        python -m pip install -e ./asapdiscovery-dataviz --no-deps
+        python -m pip install -e ./asapdiscovery-docking --no-deps
+        python -m pip install -e ./asapdiscovery-ml --no-deps
+        python -m pip install -e ./asapdiscovery-modeling --no-deps
+        python -m pip install -e ./asapdiscovery-simulation --no-deps
+        micromamba list
+
+    - name: Run tests
+      env:
+        CDDTOKEN: ${{ secrets.ASAP_CDD_VAULT_TOKEN_READ_ONLY }}
+        MOONSHOT_CDD_VAULT_NUMBER: ${{ secrets.MOONSHOT_CDD_VAULT_NUMBER }}
+      run: |
+        # run each package test suite; append to coverage file
+        # Exit immediately if a command exits with a non-zero status.
+        set -e
+        pytest -n auto --durations=10 -v --cov-report=xml --cov-report=term --color=yes \
+                       --cov=asapdiscovery-simulation \
+                       asapdiscovery-simulation/asapdiscovery/simulation/tests
+
+    - name: Upload Code Coverage to Codecov
+      uses: codecov/codecov-action@v3
+      # Don't upload coverage scheduled or on fork
+      if: ${{ github.repository == 'choderalab/asapdiscovery'
+              && github.event != 'schedule' }}
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+        fail_ci_if_error: false


### PR DESCRIPTION
## Description
Testing if separating workflows for packages fixes our CI.

In this case it is testing `macos` in a single workflow for all subpackages. This is possible since the "offending" tests were skipped for this OS.

On the other hand, we are separating all subpackages tests for `linux`. It is going to be a bit annoying when we need to update them, but I think it's better to have a single approach (everything separated and "flexible") than having to think what is separated and what isn't. We would need to study if we hit a limit with the amount of workflows or workers that we can run in the project but I think we are fine that way as far as I have tested.

Resolves #265 
Resolves #480 