### PR TITLE
Add fitness interactions

### DIFF
--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -254,7 +254,6 @@ class HTMLVisualizer:
         backbone_atoms = [ at.GetIdx() for at in self.protein.GetAtoms(oechem.OEIsBackboneAtom()) ]
 
         # with oe, iterate over atoms until this one's found. then use oechem.OEIsBackboneAtom
-        import sys
         is_backbone = False
         for idx, res_coords in self.protein.GetCoords().items():
             # round to 3 because OE pointlessly extends the coordinates float.
@@ -271,7 +270,6 @@ class HTMLVisualizer:
             # in which case the above coordinate matching doesn't find any atoms. pi-pi of this form
             # can never be on backbone anyway, so this works.
             return False
-        # sys.exit()
 
 
     def get_interaction_fitness_color(self, plip_xml_dict) -> str:

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -242,10 +242,31 @@ class HTMLVisualizer:
             return "#8C4099"
         else:
             raise ValueError(f"Interaction type {intn_type} not recognized.")
+        
+    def get_interaction_fitness_color(self, plip_xml_dict) -> str:
+        """
+        Get fitness color for a residue. If the interaction is with a backbone atom on 
+        the residue, color it green. 
+        """
+        # first get the fitness color of the residue the interaction hits, this
+        # can be white->red or blue if fitness data is missing.
+        intn_color = None
+        for fitness_color, res_nums in self.make_color_res_fitness().items():
+            if int(plip_xml_dict["resnr"]) in res_nums:
+                intn_color = fitness_color
+                break
 
+        # overwrite the interaction as green if it hits a backbone atom.
+        if self.is_backbone_residue(plip_xml_dict["protcoo"]["x"], 
+                                    plip_xml_dict["protcoo"]["y"], 
+                                    plip_xml_dict["protcoo"]["z"]):
+            intn_color = "#008000"
+        
+        return intn_color
+        
     def build_interaction_dict(self, plip_xml_dict, intn_counter, intn_type) -> Union:
         """
-        Parses a PLIP interaction dict
+        Parses a PLIP interaction dict and builds the dict key values needed for 3DMol.
         """
         k = f"{intn_counter}_{plip_xml_dict['restype']}{plip_xml_dict['resnr']}.{plip_xml_dict['reschain']}"
 
@@ -258,7 +279,9 @@ class HTMLVisualizer:
             "prot_at_z": plip_xml_dict["protcoo"]["z"],
             "type": intn_type,
             "color": self.get_interaction_color(intn_type),
+            "color_fitness": self.get_interaction_fitness_color(plip_xml_dict),
         }
+        
         return k, v
 
     @staticmethod

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -242,25 +242,28 @@ class HTMLVisualizer:
             return "#8C4099"
         else:
             raise ValueError(f"Interaction type {intn_type} not recognized.")
-        
+
     def is_backbone_residue(self, x, y, z) -> bool:
         """
         Given xyz coordinates, find the atom in the protein and return whether
         it is a backbone atom. This would be much easier if PLIP would return
         the atom idx of the protein, currently all we have are the coordinates.
         """
-        # make a list with this protein's backbone atom indices. Could do higher up, 
-        # but this is very fast so ok to repeat. 
-        backbone_atoms = [ at.GetIdx() for at in self.protein.GetAtoms(oechem.OEIsBackboneAtom()) ]
+        # make a list with this protein's backbone atom indices. Could do higher up,
+        # but this is very fast so ok to repeat.
+        backbone_atoms = [
+            at.GetIdx() for at in self.protein.GetAtoms(oechem.OEIsBackboneAtom())
+        ]
 
         # with oe, iterate over atoms until this one's found. then use oechem.OEIsBackboneAtom
         is_backbone = False
         for idx, res_coords in self.protein.GetCoords().items():
             # round to 3 because OE pointlessly extends the coordinates float.
-            if float(x) == round(res_coords[0], 3) and \
-                float(y) == round(res_coords[1], 3) and \
-                float(z) == round(res_coords[2], 3):
-
+            if (
+                float(x) == round(res_coords[0], 3)
+                and float(y) == round(res_coords[1], 3)
+                and float(z) == round(res_coords[2], 3)
+            ):
                 is_backbone = True if idx in backbone_atoms else False
 
         if is_backbone:
@@ -271,11 +274,10 @@ class HTMLVisualizer:
             # can never be on backbone anyway, so this works.
             return False
 
-
     def get_interaction_fitness_color(self, plip_xml_dict) -> str:
         """
-        Get fitness color for a residue. If the interaction is with a backbone atom on 
-        the residue, color it green. 
+        Get fitness color for a residue. If the interaction is with a backbone atom on
+        the residue, color it green.
         """
         # first get the fitness color of the residue the interaction hits, this
         # can be white->red or blue if fitness data is missing.
@@ -286,13 +288,15 @@ class HTMLVisualizer:
                 break
 
         # overwrite the interaction as green if it hits a backbone atom.
-        if self.is_backbone_residue(plip_xml_dict["protcoo"]["x"], 
-                                    plip_xml_dict["protcoo"]["y"], 
-                                    plip_xml_dict["protcoo"]["z"]):
+        if self.is_backbone_residue(
+            plip_xml_dict["protcoo"]["x"],
+            plip_xml_dict["protcoo"]["y"],
+            plip_xml_dict["protcoo"]["z"],
+        ):
             intn_color = "#008000"
-        
+
         return intn_color
-        
+
     def build_interaction_dict(self, plip_xml_dict, intn_counter, intn_type) -> Union:
         """
         Parses a PLIP interaction dict and builds the dict key values needed for 3DMol.

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -299,6 +299,10 @@ class HTMLVisualizer:
         """
         k = f"{intn_counter}_{plip_xml_dict['restype']}{plip_xml_dict['resnr']}.{plip_xml_dict['reschain']}"
 
+        if self.color_method == "fitness":
+            intn_color = self.get_interaction_fitness_color(plip_xml_dict)
+        else:
+            intn_color = self.get_interaction_color(intn_type)
         v = {
             "lig_at_x": plip_xml_dict["ligcoo"]["x"],
             "lig_at_y": plip_xml_dict["ligcoo"]["y"],
@@ -307,10 +311,8 @@ class HTMLVisualizer:
             "prot_at_y": plip_xml_dict["protcoo"]["y"],
             "prot_at_z": plip_xml_dict["protcoo"]["z"],
             "type": intn_type,
-            "color": self.get_interaction_color(intn_type),
-            "color_fitness": self.get_interaction_fitness_color(plip_xml_dict),
+            "color": intn_color,
         }
-        
         return k, v
 
     @staticmethod

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -243,6 +243,37 @@ class HTMLVisualizer:
         else:
             raise ValueError(f"Interaction type {intn_type} not recognized.")
         
+    def is_backbone_residue(self, x, y, z) -> bool:
+        """
+        Given xyz coordinates, find the atom in the protein and return whether
+        it is a backbone atom. This would be much easier if PLIP would return
+        the atom idx of the protein, currently all we have are the coordinates.
+        """
+        # make a list with this protein's backbone atom indices. Could do higher up, 
+        # but this is very fast so ok to repeat. 
+        backbone_atoms = [ at.GetIdx() for at in self.protein.GetAtoms(oechem.OEIsBackboneAtom()) ]
+
+        # with oe, iterate over atoms until this one's found. then use oechem.OEIsBackboneAtom
+        import sys
+        is_backbone = False
+        for idx, res_coords in self.protein.GetCoords().items():
+            # round to 3 because OE pointlessly extends the coordinates float.
+            if float(x) == round(res_coords[0], 3) and \
+                float(y) == round(res_coords[1], 3) and \
+                float(z) == round(res_coords[2], 3):
+
+                is_backbone = True if idx in backbone_atoms else False
+
+        if is_backbone:
+            return True
+        else:
+            # this also catches pi-pi stack where protein coordinates are centered to a ring (e.g. Phe),
+            # in which case the above coordinate matching doesn't find any atoms. pi-pi of this form
+            # can never be on backbone anyway, so this works.
+            return False
+        # sys.exit()
+
+
     def get_interaction_fitness_color(self, plip_xml_dict) -> str:
         """
         Get fitness color for a residue. If the interaction is with a backbone atom on 


### PR DESCRIPTION
Adjust interaction depiction in the case of a `fitness` HTML viz. Here we're going to color interactions by fitness (of the residue it hits) instead of by interaction type (which can be inferred easily anyway). This will enable the viewer to quickly see if a posed compound is interacting with mutable residues or not. New depiction with interactions colored by fitness:

![image](https://github.com/choderalab/asapdiscovery/assets/43140137/a872e4f5-152f-4969-afab-19c2c7c5c411)

We're adding:
- color interactions the same way as residues (white=no fit mutants, all the way to deep red which = many fit mutants)
- color interactions green if they hit the protein backbone (this is a good tactic and should be encouraged by highlighting it a separate color)

One issue is that light-red and white are difficult to distinguish. This also applies to residue surface coloring, so should be handled in a separate PR. We may want to rethink how we're coloring residues because even if there is a single fit mutant this means the virus *will* mutate to it, so it should be highlighted more clearly compared to straight white.