### PR TITLE
Add ability to run inference directly on OEMol

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -14,7 +14,6 @@ from asapdiscovery.data.openeye import (
     load_openeye_sdf,
     oechem,
     oedocking,
-    save_openeye_pdb,
     save_openeye_sdf,
 )
 from asapdiscovery.data.utils import check_name_length_and_truncate

--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -502,15 +502,9 @@ def dock_and_score_pose_oe(
                 float(oechem.OEGetSDData(conf, f"Docking_{docking_id}_Chemgauss4"))
             )
             if schnet_model is not None:
-                # TODO: this is a hack, we should be able to do this without saving
-                # the file to disk see # 253
-                outpath = Path(out_dir) / Path(".posed_mol_schnet_temp.pdb")
-                # join with the protein only structure
                 combined = combine_protein_ligand(prot, conf)
-                pdb_temp = save_openeye_pdb(combined, outpath)
-                schnet_score = schnet_model.predict_from_structure_file(pdb_temp)
+                schnet_score = schnet_model.predict_from_oemol(combined)
                 schnet_scores.append(schnet_score)
-                outpath.unlink()
             else:
                 schnet_scores.append(np.nan)
 

--- a/asapdiscovery-ml/asapdiscovery/ml/inference/inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/inference/inference.py
@@ -300,8 +300,9 @@ class StructuralInference(InferenceBase):
         np.ndarray or float
             Model prediction(s)
         """
-        from asapdiscovery.data.openeye import oechem, oemol_to_pdb_string
         from io import StringIO
+
+        from asapdiscovery.data.openeye import oechem, oemol_to_pdb_string
 
         if isinstance(pose, oechem.OEMolBase):
             pose = [pose]

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
@@ -160,3 +160,14 @@ def test_schnet_inference_predict_from_pose(docked_structure_file):
     c, pose = dataset[0]
     output = inference_cls.predict(pose)
     assert output is not None
+
+
+def test_schnet_inference_predict_from_oemol(docked_structure_file):
+    from asapdiscovery.data.openeye import load_openeye_pdb
+
+    inference_cls = SchnetInference.from_latest_by_target("SARS-CoV-2-Mpro")
+
+    pose_oemol = load_openeye_pdb(docked_structure_file)
+    assert inference_cls is not None
+    output = inference_cls.predict_from_oemol(pose_oemol)
+    assert output is not None


### PR DESCRIPTION
Add ability to run inference directly on OEMol for the `StructuralInference` class. Once the new docking stuff is merged we can also add a method to predict from `DockingResult` object if we want. Closes #253 
