### PR TITLE
Adjust molecule filtering to make more sense

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
+++ b/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
@@ -41,52 +41,52 @@ files:
 
   # output files for testing filtering
   - resource: test_filter_achiral_enantiopure_out.csv
-    sha256hash: d6fbe1e77f306091142ba1c853c0bf2c4586786042498dbc770a30f795daabe0
+    sha256hash: f49f799bf6bfadda62f2a2310cd8875eed3eee8a3b013d5e8de002632aac2ed9
 
   - resource: test_filter_achiral_enantiopure_semiquant_out.csv
-    sha256hash: 8965a8b36c753f59d043313cb6bcc53bea18d6ac8de1f8188646fd4e8f084fa4
+    sha256hash: d6fbe1e77f306091142ba1c853c0bf2c4586786042498dbc770a30f795daabe0
 
   - resource: test_filter_achiral_out.csv
-    sha256hash: f7b8425e20b64a8d42701a2fd666c5f4ffa8ba4e8bc5ba16401990c54c115f7d
+    sha256hash: ed73edd9e035aa786ec9a2af37fe9035f258043abdce41ca07061bf5cc3b03a1
 
   - resource: test_filter_achiral_racemic_enantiopure_out.csv
-    sha256hash: 48f75eaf8c36feede6e7a7867b41af80ebd8be5108704bb51d0c1eca81060127
+    sha256hash: 2d22e4fa9633e70a5d1b8c9cd7f5f699134bf3c1db0dea1163c1e397492908a4
 
   - resource: test_filter_achiral_racemic_enantiopure_semiquant_out.csv
     sha256hash: 48f75eaf8c36feede6e7a7867b41af80ebd8be5108704bb51d0c1eca81060127
 
   - resource: test_filter_achiral_racemic_out.csv
-    sha256hash: 125842ec72a3a861c874879bd3e12cac972744acdb488f7eff259bd711423dbf
+    sha256hash: 7010e7535e46babef6b32746eb37cf3b80d24a6dc01ccab2770931bae8b7bf0e
 
   - resource: test_filter_achiral_racemic_semiquant_out.csv
-    sha256hash: d1da81ee982ac6f3b40f520460711a94e1240fd6fd4bf29d8a48b4631ba84df0
+    sha256hash: 125842ec72a3a861c874879bd3e12cac972744acdb488f7eff259bd711423dbf
 
   - resource: test_filter_achiral_semiquant_out.csv
-    sha256hash: 223d018df5fe9e3dbe013b8cd02d4e2206f61ca9429303c1dc01a58bef6d1afc
+    sha256hash: f7b8425e20b64a8d42701a2fd666c5f4ffa8ba4e8bc5ba16401990c54c115f7d
 
   - resource: test_filter_enantiopure_out.csv
-    sha256hash: b4e1e4a71831537db0dda7a82a5874aa4a8427050cdaaa581fce4ed88bc72fcb
+    sha256hash: fcf5141a426d4137ca18968a9bd42851cd7bb778df31020bc349067d9f112db2
 
   - resource: test_filter_enantiopure_semiquant_out.csv
-    sha256hash: 2023963421d626c704fbca663f0c9014992290c0c8f146e5b5126085e4afe02e
+    sha256hash: b4e1e4a71831537db0dda7a82a5874aa4a8427050cdaaa581fce4ed88bc72fcb
 
   - resource: test_filter_out.csv
     sha256hash: 6f0fc5096041e06f3daf5754f72760ef05ded36247a6e822af1bbfa34294612b
 
   - resource: test_filter_racemic_enantiopure_out.csv
-    sha256hash: 19507c742903b0ec11ea0ecd934cf0a61981d256b3f6b02aa22af2259d2e88fd
+    sha256hash: a2d38e8231da349ec608bf546db428f05d98388823ff06c15a8e599560f24f70
 
   - resource: test_filter_racemic_enantiopure_semiquant_out.csv
-    sha256hash: 20db83db30393d332e53c6ad2009afbda79e398213f7727db000e9feec70d402
+    sha256hash: 19507c742903b0ec11ea0ecd934cf0a61981d256b3f6b02aa22af2259d2e88fd
 
   - resource: test_filter_racemic_out.csv
-    sha256hash: 8900f160e270ad37302ddecbc154fe51468c13ee0bda8961223fe62c73711528
+    sha256hash: be7c5cd26804f59f0c8936a9195bae027cc110943b2c04312070a9aa91a4a617
 
   - resource: test_filter_racemic_semiquant_out.csv
-    sha256hash: 87b22105b81217dde0b9aab17e98e16e6eafb297b0ef04813f7a7f6e1a95360c
+    sha256hash: 8900f160e270ad37302ddecbc154fe51468c13ee0bda8961223fe62c73711528
 
   - resource: test_filter_semiquant_out.csv
-    sha256hash: c6892cda97ae7d9af3ec68bcd7f0dd4b8c7a77b58e6b8ad30e7f7d92186b726c
+    sha256hash: 6f0fc5096041e06f3daf5754f72760ef05ded36247a6e822af1bbfa34294612b
 
   # input file for testing CDD parsing
   - resource: test_parse_in.csv

--- a/asapdiscovery-data/asapdiscovery/data/utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/utils.py
@@ -806,18 +806,23 @@ def filter_molecules_dataframe(
     semiquant_label = [
         is_semiquant(ic50) for ic50 in mol_df[f"{assay_name}: IC50 (µM)"]
     ]
-    keep_idx = [
-        (retain_achiral and achiral_label[i])
-        or (retain_racemic and racemic_label[i])
-        or (retain_enantiopure and enantiopure_label[i])
-        or (retain_semiquantitative_data and semiquant_label[i])
-        for i in range(mol_df.shape[0])
-    ]
-
     mol_df["achiral"] = achiral_label
     mol_df["racemic"] = racemic_label
     mol_df["enantiopure"] = enantiopure_label
     mol_df["semiquant"] = semiquant_label
+
+    # Check which molcules to keep
+    achiral_keep_idx = np.asarray([retain_achiral and lab for lab in achiral_label])
+    racemic_keep_idx = np.asarray([retain_racemic and lab for lab in racemic_label])
+    enantiopure_keep_idx = np.asarray(
+        [retain_enantiopure and lab for lab in enantiopure_label]
+    )
+    keep_idx = achiral_keep_idx | racemic_keep_idx | enantiopure_keep_idx
+
+    # If we do want to keep semiquant data, don't need to do any further filtering
+    if not retain_semiquantitative_data:
+        # Only want to keep non semi-quant data, so negate label first before taking &
+        keep_idx &= ~np.asarray(semiquant_label)
 
     mol_df = mol_df.loc[keep_idx, :]
     logging.debug(f"  dataframe contains {mol_df.shape[0]} entries after filtering")

--- a/asapdiscovery-data/asapdiscovery/data/utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/utils.py
@@ -734,19 +734,21 @@ def filter_molecules_dataframe(
     from rdkit.Chem import FindMolChiralCenters, MolFromSmiles
 
     # Define functions to evaluate whether molecule is achiral, racemic, or resolved
-    is_achiral = (
-        lambda smi: len(
-            FindMolChiralCenters(
-                MolFromSmiles(smi),
-                includeUnassigned=True,
-                includeCIP=False,
-                useLegacyImplementation=False,
+    def is_achiral(smi):
+        return (
+            len(
+                FindMolChiralCenters(
+                    MolFromSmiles(smi),
+                    includeUnassigned=True,
+                    includeCIP=False,
+                    useLegacyImplementation=False,
+                )
             )
+            == 0
         )
-        == 0
-    )
-    is_racemic = (
-        lambda smi: (
+
+    def is_racemic(smi):
+        return (
             len(
                 FindMolChiralCenters(
                     MolFromSmiles(smi),
@@ -763,9 +765,9 @@ def filter_molecules_dataframe(
                     useLegacyImplementation=False,
                 )
             )
+            > 0
         )
-        > 0
-    )
+
     is_enantiopure = lambda smi: (not is_achiral(smi)) and (  # noqa: E731
         not is_racemic(smi)
     )


### PR DESCRIPTION
Changes filtering molecules that were downloaded from CDD so that data being semi-quantitative is no longer a criteria for inclusion, but only for exclusion if `retain_semiquantitative_data == False`. Fixes #539.