### PR TITLE
add chemical file formats  to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,24 @@ cluster_scripts/log_files
 *.stderr
 *.out
 *-log.txt
+
+
+# structure and molecule files
+*.xyz
+*.mol
+*.pdb
+*.cif
+*.sdf
+*.mol2
+*.oedu
+*.oeb
+*.oez
+*.mmcif
+*.mmtf
+*.fasta
+*.smi
+*.smiles
+# gzip versions of the above
+*.inchi
+*.inchikey
+*.gz 

--- a/.gitignore
+++ b/.gitignore
@@ -142,4 +142,4 @@ cluster_scripts/log_files
 # gzip versions of the above
 *.inchi
 *.inchikey
-*.gz 
+*.gz


### PR DESCRIPTION
Adds chemical file formats to gitignore.

initial partial fix of #538 