### PR TITLE
Make pyproj.tomls to not install anything

### DIFF
--- a/asapdiscovery-alchemy/pyproject.toml
+++ b/asapdiscovery-alchemy/pyproject.toml
@@ -18,9 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "alchemiscale"
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/asapdiscovery-data/pyproject.toml
+++ b/asapdiscovery-data/pyproject.toml
@@ -18,21 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "pandas",
-    "rdkit",
-    "mdtraj",
-    #"openeye-toolkit",
-    "sigfig",
-    #"pymol",
-    "requests",
-    "typing-extensions",
-    "click",
-    "boto3",
-    "moto",
-    "flask",
-    "flask_cors"
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/asapdiscovery-dataviz/pyproject.toml
+++ b/asapdiscovery-dataviz/pyproject.toml
@@ -18,12 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "plotly",
-    "dash",
-    "pandas",
-    #"pymol",
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/asapdiscovery-docking/pyproject.toml
+++ b/asapdiscovery-docking/pyproject.toml
@@ -18,13 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "pandas",
-    "rdkit",
-    #"openeye-toolkit",
-    "plotly",
-    "pebble",
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/asapdiscovery-ml/pyproject.toml
+++ b/asapdiscovery-ml/pyproject.toml
@@ -18,8 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/asapdiscovery-modeling/pyproject.toml
+++ b/asapdiscovery-modeling/pyproject.toml
@@ -18,12 +18,7 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",
 ]
-dependencies = [
-    "pandas",
-    "rdkit",
-    #"openeye-toolkit",
-    "plotly",
-]
+dependencies = []
 
 [project.urls]
 "Homepage" = "https://github.com/choderalab/asapdiscovery"

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -35,6 +35,7 @@ dependencies:
   - moto
   - flask
   - flask-cors
+  - typing-extensions
 
   # ml
   - pytorch
@@ -67,6 +68,8 @@ dependencies:
   - pymol-open-source
   - gifsicle
   - plip
+  - plotly
+  - dash
 
   # simulation
   - openfe =0.11.0

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -35,6 +35,7 @@ dependencies:
   - moto
   - flask
   - flask-cors
+  - typing-extensions
 
   # ml
   - pytorch
@@ -69,6 +70,8 @@ dependencies:
   - pymol-open-source
   - gifsicle
   - plip
+  - plotly
+  - dash
 
   # simulation
   - openfe =0.11.0


### PR DESCRIPTION
Fixes #548

Makes pyproject.tomls for subprojects empty, meaning you should use the carefully managed conda env to install everything. 

We can re-populate when things are more settled for subpackages if we like. 