### PR TITLE
Fix scorer jamming when no model available for a given target

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/scorer_v2.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer_v2.py
@@ -2,6 +2,7 @@ import abc
 from enum import Enum
 from typing import ClassVar, Optional
 from warnings import warn
+
 import dask
 import numpy as np
 import pandas as pd

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer_v2.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer_v2.py
@@ -1,7 +1,7 @@
 import abc
 from enum import Enum
 from typing import ClassVar, Optional
-
+from warnings import warn
 import dask
 import numpy as np
 import pandas as pd
@@ -218,11 +218,17 @@ class MLModelScorer(ScorerBase):
             raise Exception("trying to instantiate some kind a baseclass")
         inference_cls = get_inference_cls_from_model_type(cls.model_type)
         inference_instance = inference_cls.from_latest_by_target(target)
-        return cls(
-            targets=inference_instance.targets,
-            model_name=inference_instance.model_name,
-            inference_cls=inference_instance,
-        )
+        if inference_instance is None:
+            warn(
+                f"no ML model of type {cls.model_type} found for target: {target}, skipping"
+            )
+            return None
+        else:
+            return cls(
+                targets=inference_instance.targets,
+                model_name=inference_instance.model_name,
+                inference_cls=inference_instance,
+            )
 
     @staticmethod
     def from_latest_by_target_and_type(target: TargetTags, type: MLModelType):

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
@@ -403,9 +403,11 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
     if inputs.ml_scorers:
         for ml_scorer in inputs.ml_scorers:
             logger.info(f"Loading ml scorer: {ml_scorer}")
-            scorers.append(
-                MLModelScorer.from_latest_by_target_and_type(inputs.target, ml_scorer)
+            scorer = MLModelScorer.from_latest_by_target_and_type(
+                inputs.target, ml_scorer
             )
+            if scorer:
+                scorers.append(scorer)
 
     # score results
     logger.info("Scoring docking results")


### PR DESCRIPTION
For new targets without ML models, we need to gracefully handle no available models in new scorer API