### PR TITLE
add fitness option to `pose-to-viz.py`

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/fitness.py
+++ b/asapdiscovery-data/asapdiscovery/data/fitness.py
@@ -133,8 +133,8 @@ def parse_fitness_json(target: TargetTags) -> pd.DataFrame:
             f"Specified target is not valid, must be one of: {TargetTags.get_values()}"
         )
 
-    if target == "MERS-CoV-Mpro":
-        raise NotImplementedError("MERS-CoV-Mpro fitness data not yet available.")
+    if target not in ("SARS-CoV-2-Mpro", "SARS-CoV-2-Mac1"):
+        raise NotImplementedError(f"Fitness data not yet available for {target}. Add to metadata if/when available.")
 
     with open(SARS_CoV_2_fitness_data) as f:
         data = json.load(f)

--- a/asapdiscovery-data/asapdiscovery/data/fitness.py
+++ b/asapdiscovery-data/asapdiscovery/data/fitness.py
@@ -134,7 +134,9 @@ def parse_fitness_json(target: TargetTags) -> pd.DataFrame:
         )
 
     if target not in ("SARS-CoV-2-Mpro", "SARS-CoV-2-Mac1"):
-        raise NotImplementedError(f"Fitness data not yet available for {target}. Add to metadata if/when available.")
+        raise NotImplementedError(
+            f"Fitness data not yet available for {target}. Add to metadata if/when available."
+        )
 
     with open(SARS_CoV_2_fitness_data) as f:
         data = json.load(f)

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/scripts/pose_to_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/scripts/pose_to_viz.py
@@ -31,6 +31,15 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--viz-type",
+    type=str,
+    required=False,
+    default="subpockets",
+    choices=["subpockets", "fitness"],
+    help="Whether to show subpocket color mapping (default) or fitness color mapping",
+)
+
+parser.add_argument(
     "--out",
     type=str,
     required=True,

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/scripts/pose_to_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/scripts/pose_to_viz.py
@@ -31,7 +31,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    "--viz-type",
+    "--color-method",
     type=str,
     required=False,
     default="subpockets",
@@ -72,6 +72,7 @@ def main():
     html_visualizer = HTMLVisualizer(
         poses=[str(pose)],
         output_paths=[out],
+        color_method=args.color_method,
         target=args.viz_target,
         protein=protein,
         logger=logger,


### PR DESCRIPTION
quick PR that satisfies a requirement for https://github.com/choderalab/asapdiscovery/issues/566, now have a CLI endpoint to generate either a subpocket or fitness HTML starting from a PDB file and an SDF.
