### PR TITLE
Fix logging error in run_openeye_oe

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py
@@ -609,10 +609,10 @@ def main():
                     break
                 except TimeoutError:
                     # This compound:xtal combination timed out
-                    logger.error("Docking timed out for", docking_run_name)
+                    logger.error(f"Docking timed out for: {docking_run_name}")
                     failed_runs += [docking_run_name]
                 except pebble.ProcessExpired as e:
-                    logger.error("Docking failed for", docking_run_name)
+                    logger.error(f"Docking failed for: {docking_run_name}")
                     logger.error(f"\t{e}. Exit code {e.exitcode}")
                     failed_runs += [docking_run_name]
                 except Exception as e:


### PR DESCRIPTION
## Description
It's embarassing to get an error within the error messaging
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/paynea/miniconda3/envs/ad-3.9/lib/python3.9/logging/__init__.py", line 1083, in emit
    msg = self.format(record)
  File "/home/paynea/miniconda3/envs/ad-3.9/lib/python3.9/logging/__init__.py", line 927, in format
    return fmt.format(record)
  File "/home/paynea/miniconda3/envs/ad-3.9/lib/python3.9/logging/__init__.py", line 663, in format
    record.message = record.getMessage()
  File "/home/paynea/miniconda3/envs/ad-3.9/lib/python3.9/logging/__init__.py", line 367, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  File "/home/paynea/miniconda3/envs/ad-3.9/bin/run-docking-oe", line 8, in <module>
    sys.exit(main())
  File "/lila/data/chodera/paynea/asapdiscovery/asapdiscovery-docking/asapdiscovery/docking/scripts/run_docking_oe.py", line 608, in main
    logger.error("Docking timed out for", docking_run_name)
Message: 'Docking timed out for'
Arguments: ('hybrid',)
```

## Todos
  - [x] fix how the string is passed

## Status
- [x] Ready to go
