### PR TITLE
Fix protein prep loop db filepath 

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
+++ b/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
@@ -240,3 +240,7 @@ files:
 
   - resource: du_cache/Mpro-x1002_0A_bound.oedu
     sha256hash: e1362be3ef584e68d0f25c99d4a6c26497cb4f8633585bf04ea389b30c1c468d
+
+  # protein prep testing
+  - resource: SARS2_Mac1A-A1013.pdb
+    sha256hash: 2109f9581336b5e6332fee3136f59ef677a3dbf76cdabf0b4316ec705a1a4a3b

--- a/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep_v2.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep_v2.py
@@ -6,8 +6,6 @@ from typing import Literal, Optional, Union
 
 import dask
 import yaml
-from pydantic import BaseModel, Field, root_validator
-
 from asapdiscovery.data.dask_utils import actualise_dask_delayed_iterable
 from asapdiscovery.data.openeye import oechem
 from asapdiscovery.data.schema_v2.complex import Complex, PreppedComplex
@@ -19,6 +17,7 @@ from asapdiscovery.modeling.modeling import (
     spruce_protein,
     superpose_molecule,
 )
+from pydantic import BaseModel, Field, root_validator
 
 
 class CacheType(str, Enum):

--- a/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep_v2.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep_v2.py
@@ -6,6 +6,8 @@ from typing import Literal, Optional, Union
 
 import dask
 import yaml
+from pydantic import BaseModel, Field, root_validator
+
 from asapdiscovery.data.dask_utils import actualise_dask_delayed_iterable
 from asapdiscovery.data.openeye import oechem
 from asapdiscovery.data.schema_v2.complex import Complex, PreppedComplex
@@ -17,7 +19,6 @@ from asapdiscovery.modeling.modeling import (
     spruce_protein,
     superpose_molecule,
 )
-from pydantic import BaseModel, Field, root_validator
 
 
 class CacheType(str, Enum):
@@ -245,7 +246,7 @@ class ProteinPrepper(ProteinPrepperBase):
                 success, spruce_error_message, spruced = spruce_protein(
                     initial_prot=prot,
                     protein_sequence=protein_sequence,
-                    loop_db=str(self.loop_db),
+                    loop_db=self.loop_db,
                 )
 
                 if not success:

--- a/asapdiscovery-modeling/asapdiscovery/modeling/tests/test_protein_prep_v2.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/tests/test_protein_prep_v2.py
@@ -1,6 +1,9 @@
 import pytest
+
+from asapdiscovery.data.postera.manifold_data_validation import TargetTags
 from asapdiscovery.data.schema_v2.complex import Complex
 from asapdiscovery.data.schema_v2.structure_dir import StructureDirFactory
+from asapdiscovery.data.sequence import seqres_by_target
 from asapdiscovery.data.testing.test_resources import fetch_test_file
 from asapdiscovery.modeling.protein_prep_v2 import ProteinPrepper
 
@@ -9,6 +12,15 @@ from asapdiscovery.modeling.protein_prep_v2 import ProteinPrepper
 def cmplx():
     return Complex.from_pdb(
         fetch_test_file("structure_dir/Mpro-x0354_0A_bound.pdb"),
+        target_kwargs={"target_name": "test"},
+        ligand_kwargs={"compound_name": "test2"},
+    )
+
+
+@pytest.fixture(scope="session")
+def prep_complex():
+    return Complex.from_pdb(
+        fetch_test_file("SARS2_Mac1A-A1013.pdb"),
         target_kwargs={"target_name": "test"},
         ligand_kwargs={"compound_name": "test2"},
     )
@@ -40,9 +52,10 @@ def du_cache(du_cache_files):
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_protein_prep(cmplx, use_dask):
-    prepper = ProteinPrepper()
-    pcs = prepper.prep([cmplx], use_dask=use_dask)
+def test_protein_prep(prep_complex, use_dask):
+    target = TargetTags["SARS-CoV-2-Mac1"]
+    prepper = ProteinPrepper(loop_db=None, seqres_yaml=seqres_by_target(target))
+    pcs = prepper.prep([prep_complex], use_dask=use_dask)
     assert len(pcs) == 1
     assert pcs[0].target.target_name == "test"
     assert pcs[0].ligand.compound_name == "test2"

--- a/asapdiscovery-modeling/asapdiscovery/modeling/tests/test_protein_prep_v2.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/tests/test_protein_prep_v2.py
@@ -1,5 +1,4 @@
 import pytest
-
 from asapdiscovery.data.postera.manifold_data_validation import TargetTags
 from asapdiscovery.data.schema_v2.complex import Complex
 from asapdiscovery.data.schema_v2.structure_dir import StructureDirFactory


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.
This PR fixes an issue where the loop db file path is set to `str(None)` when not supplied by mistake causing a fatal error with openeye. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Add test for the case.

## Questions
- [ ] Question1

## Status
- [ ] Ready to go
