### PR TITLE
Add column pre-bleaching for postera

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/postera/manifold_data_validation.py
+++ b/asapdiscovery-data/asapdiscovery/data/postera/manifold_data_validation.py
@@ -313,6 +313,7 @@ def rename_output_columns_for_manifold(
     df: pd.DataFrame,
     target: str,
     output_enums: list[Enum],
+    bleach_columns: bool = True,
     manifold_validate: Optional[bool] = True,
     drop_non_output: Optional[bool] = True,
     allow: Optional[list[str]] = [],
@@ -337,6 +338,8 @@ def rename_output_columns_for_manifold(
         Target name
     output_enums : list[Enum]
         List of enums to rename the columns of
+    bleach_columns : bool, optional
+        If True, bleach the column names so that - is replaced with _ see #629 and #628
     manifold_validate : bool, optional
         If True, validate that the columns are valid for Postera Manifold
     drop_non_output : bool, optional
@@ -368,4 +371,8 @@ def rename_output_columns_for_manifold(
             )
     # rename columns
     df = df.rename(columns=mapping)
+
+    if bleach_columns:
+        df.columns = [col.replace("-", "_") for col in df.columns]
+
     return df

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
@@ -356,10 +356,18 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
 
     # rename columns for manifold
     logger.info("Renaming columns for manifold")
+
+    if inputs.postera_upload:
+        bleach_columns = True
+        logger.info("Bleaching column names for Postera upload, see issue #629, 628")
+    else:
+        bleach_columns = False
+
     result_df = rename_output_columns_for_manifold(
         scores_df,
         inputs.target,
         [DockingResultCols],
+        bleach_columns=bleach_columns,
         manifold_validate=True,
         drop_non_output=True,
         allow=[DockingResultCols.LIGAND_ID.value],


### PR DESCRIPTION
Adds pre-bleaching of column names to the postera convention ("_" not "-")  when uploading to postera, so that data can be joined to existing columns, meaning we don't have to erase all pre-existing custom data. See #629 and #628 for more info. 

**THIS SHOULD BE REVERTED ONCE UPSTREAM #628 IS IMPLEMENTED**