### PR TITLE
Add Developer Certificate of Origin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,14 @@ Provide a brief description of the PR's purpose here.
 
 ## Todos
 Notable points that this PR has either accomplished or will accomplish.
-  - [ ] TODO 1
+- [ ] Point 1 ...
 
 ## Questions
-- [ ] Question1
+- [ ] Question 1 .. 
 
 ## Status
 - [ ] Ready to go
+
+
+## Developers certificate of origin
+- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Notable points that this PR has either accomplished or will accomplish.
 - [ ] Point 1 ...
 
 ## Questions
-- [ ] Question 1 .. 
+- [ ] Question 1 ..
 
 ## Status
 - [ ] Ready to go


### PR DESCRIPTION
Fixes #176 

## Description
Adds developer certificate of origin so that contributors can affirm that they contribute under the LICENSE.  This is the least invasive way to go, and we should probably have this in place is my understanding. I will wait for confirmation from @jchodera 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [X] Adds developer certificate of origin

## Status
- [X] Ready to go
