### PR TITLE
Add new models trained with better learning rate

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
@@ -201,7 +201,7 @@ asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20:
     sha256hash: 18bc1633f15aa892de48d691356aad63894bfc6135f92e9ec7ac27a6c36edb91
   config:
     resource: asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20.json
-    sha256hash: 20e44f25882fbda23acc821b63121fa621b3437480c366cdeaf1c28b8e6aa06c
+    sha256hash: 7065befd76cdcc79b4211c624a948c17a989110ebad3971b6bd10438e674a5fe
   last_updated: 2023-11-20
   targets:
     - SARS-CoV-2-Mpro

--- a/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
@@ -189,3 +189,20 @@ asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.08.25:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+
+
+# new SchNet model trained with a lower learning rate to avoid the weights collapsing
+# trained on MTENN 0.4.0
+asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20:
+  type: schnet
+  base_url: https://asap-discovery-ml-weights.s3.amazonaws.com/production/schnet/
+  weights:
+    resource: asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20.th
+    sha256hash: 18bc1633f15aa892de48d691356aad63894bfc6135f92e9ec7ac27a6c36edb91
+  config:
+    resource: asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20.json
+    sha256hash: 20e44f25882fbda23acc821b63121fa621b3437480c366cdeaf1c28b8e6aa06c
+  last_updated: 2023-11-20
+  targets:
+    - SARS-CoV-2-Mpro
+    - MERS-CoV-Mpro

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
@@ -64,12 +64,14 @@ def test_get_model():
     model = ASAPMLModelRegistry.get_model("gat_test_v0")
     assert model.type == "GAT"
 
-
-def test_get_latest_model_for_target_and_type():
+@pytest.mark.parametrize("type", ["GAT", "schnet"])
+def test_get_latest_model_for_target_and_type(type):
     model = ASAPMLModelRegistry.get_latest_model_for_target_and_type(
-        "SARS-CoV-2-Mpro", "schnet"
+        "SARS-CoV-2-Mpro", type
     )
     other_models = ASAPMLModelRegistry.get_models_for_target("SARS-CoV-2-Mpro")
+    # filter by type
+    other_models = [m for m in other_models if m.type == type]
     # sort by date updated
     other_models.sort(key=lambda x: x.last_updated, reverse=True)
     assert model == other_models[0]

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
@@ -67,7 +67,7 @@ def test_get_model():
 
 def test_get_latest_model_for_target_and_type():
     model = ASAPMLModelRegistry.get_latest_model_for_target_and_type(
-        "SARS-CoV-2-Mpro", "GAT"
+        "SARS-CoV-2-Mpro", "schnet"
     )
     other_models = ASAPMLModelRegistry.get_models_for_target("SARS-CoV-2-Mpro")
     # sort by date updated

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_models.py
@@ -64,6 +64,7 @@ def test_get_model():
     model = ASAPMLModelRegistry.get_model("gat_test_v0")
     assert model.type == "GAT"
 
+
 @pytest.mark.parametrize("type", ["GAT", "schnet"])
 def test_get_latest_model_for_target_and_type(type):
     model = ASAPMLModelRegistry.get_latest_model_for_target_and_type(


### PR DESCRIPTION
Add new SchNet model trained with a lower learning rate to avoid the weights collapsing. These models were trained using `mtenn v0.4.0`, so probably shouldn't be used with previous versions. This is the version that's pinned in the `asapdiscovery` conda env files, so it shouldn't cause any issues.