### PR TITLE
Adds local GPU dask client override for local dask mode in small-scale docking

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/dask_utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/dask_utils.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from typing import Optional
 
 import dask
+from dask_cuda import LocalCUDACluster
 from asapdiscovery.data.enum import StringEnum
 from dask import config as cfg
 from dask.utils import parse_timedelta
@@ -57,6 +58,7 @@ class DaskType(StringEnum):
     """
 
     LOCAL = "local"
+    LOCAL_GPU = "local-gpu"
     LILAC_GPU = "lilac-gpu"
     LILAC_CPU = "lilac-cpu"
 
@@ -66,7 +68,7 @@ class DaskType(StringEnum):
 
 class GPU(StringEnum):
     """
-    Enum for GPU types
+    Enum for GPU types on lilac
     """
 
     GTX1080TI = "GTX1080TI"
@@ -263,9 +265,9 @@ def dask_cluster_from_type(
     dask_type : DaskType
         The type of dask client / cluster to get
     gpu : GPU, optional
-        The GPU type to use if type is GPU, by default GPU.GTX1080TI
+        The GPU type to use if type is lilac-gpu, by default GPU.GTX1080TI
     cpu : CPU, optional
-        The CPU type to use if type is CPU, by default CPU.LT
+        The CPU type to use if type is lilac-cpu, by default CPU.LT
 
     Returns
     -------
@@ -275,6 +277,8 @@ def dask_cluster_from_type(
     logger.info(f"Getting dask cluster of type {dask_type}")
     if dask_type == DaskType.LOCAL:
         cluster = LocalCluster()
+    elif dask_type == DaskType.LOCAL_GPU:
+        cluster = LocalCUDACluster()
     elif dask_type == DaskType.LILAC_GPU:
         cluster = LilacGPUDaskCluster().from_gpu(gpu).to_cluster(exclude_interface="lo")
     elif dask_type == DaskType.LILAC_CPU:

--- a/asapdiscovery-data/asapdiscovery/data/dask_utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/dask_utils.py
@@ -6,7 +6,6 @@ import dask
 from asapdiscovery.data.enum import StringEnum
 from dask import config as cfg
 from dask.utils import parse_timedelta
-from dask_cuda import LocalCUDACluster
 from dask_jobqueue import LSFCluster
 from distributed import Client, LocalCluster
 from pydantic import BaseModel, Field
@@ -278,6 +277,12 @@ def dask_cluster_from_type(
     if dask_type == DaskType.LOCAL:
         cluster = LocalCluster()
     elif dask_type == DaskType.LOCAL_GPU:
+        try:
+            from dask_cuda import LocalCUDACluster
+        except ImportError:
+            raise ImportError(
+                "dask_cuda is not installed, please install with `pip install dask_cuda`"
+            )
         cluster = LocalCUDACluster()
     elif dask_type == DaskType.LILAC_GPU:
         cluster = LilacGPUDaskCluster().from_gpu(gpu).to_cluster(exclude_interface="lo")

--- a/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
+++ b/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
@@ -188,7 +188,7 @@ files:
     sha256hash: c8473899ea40b3f4d9382fca3a2b5f76b1e878313a7287a9240bc4322a5db79d
 
   - resource: prepared_alchemy_dataset.json
-    sha256hash: 7115b9fa8ea90497b18a6794bbd661a3b3f1d399893e60e675e9303f5cb41414
+    sha256hash: c988455b3e60d84939666d521415da9c8318fc3b5b4d4606b88acc659763d46d
 
   # TYK2 FEC network for testing
   - resource: tyk2_small_network.json

--- a/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
+++ b/asapdiscovery-data/asapdiscovery/data/testing/test_files.yaml
@@ -253,7 +253,7 @@ files:
     sha256hash: 2aded7f8f4450b94b6bfeb13095ba755867918fb0195d1176165928fc7e5cd13
 
   - resource: constrained_conformer/complex.json
-    sha256hash: 3af4041a7f659465fbaba2c5e80bb1d187b4c46cd536ff61ecf30f345af6ec1d
+    sha256hash: b8adae1898deb77e429bf0904e404ac823ef4d9d9c5f5a7b38c60cc97c4ebda4
 
   - resource: constrained_conformer/mac1_ligands.smi
     sha256hash: afdab32d12c2b87b995a76368b47e945006ed58aaf66f5e798ae964ab2f123d1

--- a/asapdiscovery-docking/asapdiscovery/docking/cli.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/cli.py
@@ -250,6 +250,7 @@ def cross_docking(
     default=0.1,
     help="The confidence cutoff for POSIT results to be considered",
 )
+@click.option("--allow-dask-cuda/--no-allow-dask-cuda", default=True)
 @ligands
 @postera_args
 @pdb_file
@@ -266,6 +267,7 @@ def cross_docking(
 def small_scale(
     target: TargetTags,
     posit_confidence_cutoff: float = 0.1,
+    allow_dask_cuda: bool = True,
     ligands: Optional[str] = None,
     postera: bool = False,
     postera_molset_name: Optional[str] = None,
@@ -301,6 +303,7 @@ def small_scale(
             use_dask=use_dask,
             dask_type=dask_type,
             posit_confidence_cutoff=posit_confidence_cutoff,
+            allow_dask_cuda=allow_dask_cuda,
             filename=ligands,
             pdb_file=pdb_file,
             fragalysis_dir=fragalysis_dir,

--- a/asapdiscovery-docking/asapdiscovery/docking/tests/cli/test_docking_cli.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/tests/cli/test_docking_cli.py
@@ -25,23 +25,23 @@ def test_project_support_docking_cli_fragalysis(
 
     frag_parent_dir, _ = mpro_frag_dir
 
-    args = (
-        [
-            subcommand,
-            "--target",
-            "SARS-CoV-2-Mpro",
-            "--ligands",
-            ligand_file,
-            "--fragalysis-dir",
-            frag_parent_dir,
-            "--posit-confidence-cutoff",
-            0,
-            "--output-dir",
-            tmp_path,
-        ],
-    )
+    args = [
+        subcommand,
+        "--target",
+        "SARS-CoV-2-Mpro",
+        "--ligands",
+        ligand_file,
+        "--fragalysis-dir",
+        frag_parent_dir,
+        "--posit-confidence-cutoff",
+        0,
+        "--output-dir",
+        tmp_path,
+    ]
 
-    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+    if (
+        subcommand == "small-scale"
+    ):  # turn off dask cuda overrides for CI runners which lack GPUs
         args.extend(["--no-allow-dask-cuda"])
 
     result = runner.invoke(cli, args)
@@ -74,7 +74,9 @@ def test_project_support_docking_cli_structure_directory_dask(
         tmp_path,
     ]
 
-    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+    if (
+        subcommand == "small-scale"
+    ):  # turn off dask cuda overrides for CI runners which lack GPUs
         args.extend(["--no-allow-dask-cuda"])
 
     result = runner.invoke(cli, args)
@@ -110,7 +112,9 @@ def test_project_support_docking_cli_structure_directory_du_cache_dask(
         tmp_path,
     ]
 
-    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+    if (
+        subcommand == "small-scale"
+    ):  # turn off dask cuda overrides for CI runners which lack GPUs
         args.extend(["--no-allow-dask-cuda"])
 
     result = runner.invoke(cli, args)
@@ -141,7 +145,9 @@ def test_project_support_docking_cli_pdb_file_dask(
         tmp_path,
     ]
 
-    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+    if (
+        subcommand == "small-scale"
+    ):  # turn off dask cuda overrides for CI runners which lack GPUs
         args.extend(["--no-allow-dask-cuda"])
 
     result = runner.invoke(cli, args)

--- a/asapdiscovery-docking/asapdiscovery/docking/tests/cli/test_docking_cli.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/tests/cli/test_docking_cli.py
@@ -25,8 +25,7 @@ def test_project_support_docking_cli_fragalysis(
 
     frag_parent_dir, _ = mpro_frag_dir
 
-    result = runner.invoke(
-        cli,
+    args = (
         [
             subcommand,
             "--target",
@@ -41,6 +40,11 @@ def test_project_support_docking_cli_fragalysis(
             tmp_path,
         ],
     )
+
+    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+        args.extend(["--no-allow-dask-cuda"])
+
+    result = runner.invoke(cli, args)
     assert click_success(result)
 
 
@@ -55,23 +59,25 @@ def test_project_support_docking_cli_structure_directory_dask(
 
     struct_dir, _ = structure_dir
 
-    result = runner.invoke(
-        cli,
-        [
-            subcommand,
-            "--target",
-            "SARS-CoV-2-Mpro",
-            "--ligands",
-            ligand_file,
-            "--structure-dir",
-            struct_dir,
-            "--use-dask",  # add dask
-            "--posit-confidence-cutoff",
-            0,
-            "--output-dir",
-            tmp_path,
-        ],
-    )
+    args = [
+        subcommand,
+        "--target",
+        "SARS-CoV-2-Mpro",
+        "--ligands",
+        ligand_file,
+        "--structure-dir",
+        struct_dir,
+        "--use-dask",  # add dask
+        "--posit-confidence-cutoff",
+        0,
+        "--output-dir",
+        tmp_path,
+    ]
+
+    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+        args.extend(["--no-allow-dask-cuda"])
+
+    result = runner.invoke(cli, args)
     assert click_success(result)
 
 
@@ -87,25 +93,27 @@ def test_project_support_docking_cli_structure_directory_du_cache_dask(
     struct_dir, _ = structure_dir
     du_cache_dir, _ = du_cache
 
-    result = runner.invoke(
-        cli,
-        [
-            subcommand,
-            "--target",
-            "SARS-CoV-2-Mpro",
-            "--ligands",
-            ligand_file,
-            "--structure-dir",
-            struct_dir,
-            "--use-dask",
-            "--posit-confidence-cutoff",
-            0,
-            "--cache-dir",
-            du_cache_dir,
-            "--output-dir",
-            tmp_path,
-        ],
-    )
+    args = [
+        subcommand,
+        "--target",
+        "SARS-CoV-2-Mpro",
+        "--ligands",
+        ligand_file,
+        "--structure-dir",
+        struct_dir,
+        "--use-dask",
+        "--posit-confidence-cutoff",
+        0,
+        "--cache-dir",
+        du_cache_dir,
+        "--output-dir",
+        tmp_path,
+    ]
+
+    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+        args.extend(["--no-allow-dask-cuda"])
+
+    result = runner.invoke(cli, args)
     assert click_success(result)
 
 
@@ -118,23 +126,25 @@ def test_project_support_docking_cli_pdb_file_dask(
 ):
     runner = CliRunner()
 
-    result = runner.invoke(
-        cli,
-        [
-            subcommand,
-            "--target",
-            "SARS-CoV-2-Mpro",
-            "--ligands",
-            ligand_file,
-            "--pdb-file",
-            pdb_file,
-            "--use-dask",
-            "--posit-confidence-cutoff",
-            0,
-            "--output-dir",
-            tmp_path,
-        ],
-    )
+    args = [
+        subcommand,
+        "--target",
+        "SARS-CoV-2-Mpro",
+        "--ligands",
+        ligand_file,
+        "--pdb-file",
+        pdb_file,
+        "--use-dask",
+        "--posit-confidence-cutoff",
+        0,
+        "--output-dir",
+        tmp_path,
+    ]
+
+    if subcommand == "small-scale":  # turn off dask cuda overrides for CI
+        args.extend(["--no-allow-dask-cuda"])
+
+    result = runner.invoke(cli, args)
     assert click_success(result)
 
 
@@ -155,6 +165,7 @@ def test_small_scale_docking_md(ligand_file, pdb_file, tmp_path):
             "--pdb-file",
             pdb_file,
             "--use-dask",
+            "--no-allow-dask-cuda",
             "--posit-confidence-cutoff",
             0,
             "--output-dir",

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/large_scale_docking.py
@@ -140,7 +140,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
             dask_cluster.scale(inputs.dask_cluster_n_workers)
 
         dask_client = Client(dask_cluster)
-        dask_client.forward_logging()
+        # dask_client.forward_logging() distributed vs dask_cuda versioning issue, see # #669
         logger.info(f"Using dask client: {dask_client}")
         logger.info(f"Using dask cluster: {dask_cluster}")
         logger.info(f"Dask client dashboard: {dask_client.dashboard_link}")

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
@@ -134,7 +134,7 @@ class SmallScaleDockingInputs(PosteraDockingWorkflowInputs):
         dask_type = values.get("dask_type")
         md = values.get("md")
 
-        if dask_type.is_lilac_cpu() and md:
+        if dask_type == dask_type.LILAC_CPU and md:
             raise ValueError("Cannot run MD on a CPU cluster, please use a GPU cluster")
         return values
 
@@ -188,7 +188,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
             dask_cluster.scale(inputs.dask_cluster_n_workers)
 
         dask_client = Client(dask_cluster)
-        dask_client.forward_logging()
+        # dask_client.forward_logging() distributed vs dask_cuda versioning issue, see # #669
         logger.info(f"Using dask client: {dask_client}")
         logger.info(f"Using dask cluster: {dask_cluster}")
         logger.info(f"Dask client dashboard: {dask_client.dashboard_link}")
@@ -448,13 +448,13 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
     )
 
     if inputs.md:
-        if inputs.dask_type == DaskType.LOCAL_CPU:
+        if inputs.dask_type == DaskType.LOCAL:
             logger.info(
                 "Using local CPU dask cluster, and MD has been requested, replacing with a GPU cluster"
             )
             dask_cluster = dask_cluster_from_type(DaskType.LOCAL_GPU)
             dask_client = Client(dask_cluster)
-            dask_client.forward_logging()
+            # dask_client.forward_logging() distributed vs dask_cuda versioning issue, see # #669
             logger.info(f"Using dask client: {dask_client}")
             logger.info(f"Using dask cluster: {dask_cluster}")
             logger.info(f"Dask client dashboard: {dask_client.dashboard_link}")

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
@@ -4,7 +4,11 @@ from typing import Optional
 
 from asapdiscovery.data.aws.cloudfront import CloudFront
 from asapdiscovery.data.aws.s3 import S3
-from asapdiscovery.data.dask_utils import dask_cluster_from_type, set_dask_config
+from asapdiscovery.data.dask_utils import (
+    dask_cluster_from_type,
+    set_dask_config,
+    DaskType,
+)
 from asapdiscovery.data.fitness import target_has_fitness_data
 from asapdiscovery.data.logging import FileLogger
 from asapdiscovery.data.metadata.resources import master_structures
@@ -43,7 +47,7 @@ from asapdiscovery.modeling.protein_prep_v2 import ProteinPrepper
 from asapdiscovery.simulation.simulate import OpenMMPlatform
 from asapdiscovery.simulation.simulate_v2 import VanillaMDSimulatorV2
 from distributed import Client
-from pydantic import Field, PositiveInt, validator
+from pydantic import Field, PositiveInt, validator, root_validator
 
 
 class SmallScaleDockingInputs(PosteraDockingWorkflowInputs):
@@ -120,6 +124,19 @@ class SmallScaleDockingInputs(PosteraDockingWorkflowInputs):
                         f"ML scorer {ml_scorer} not valid, must be one of {ASAPMLModelRegistry.get_implemented_model_types()}"
                     )
         return v
+
+    @root_validator
+    @classmethod
+    def dask_type_cannot_be_lilac_cpu_and_md(cls, values):
+        """
+        Validate that the dask type is not lilac cpu if MD is requested
+        """
+        dask_type = values.get("dask_type")
+        md = values.get("md")
+
+        if dask_type.is_lilac_cpu() and md:
+            raise ValueError("Cannot run MD on a CPU cluster, please use a GPU cluster")
+        return values
 
 
 def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
@@ -431,6 +448,17 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
     )
 
     if inputs.md:
+        if inputs.dask_type == DaskType.LOCAL_CPU:
+            logger.info(
+                "Using local CPU dask cluster, and MD has been requested, replacing with a GPU cluster"
+            )
+            dask_cluster = dask_cluster_from_type(DaskType.LOCAL_GPU)
+            dask_client = Client(dask_cluster)
+            dask_client.forward_logging()
+            logger.info(f"Using dask client: {dask_client}")
+            logger.info(f"Using dask cluster: {dask_cluster}")
+            logger.info(f"Dask client dashboard: {dask_client.dashboard_link}")
+
         md_output_dir = output_dir / "md"
         md_simulator = VanillaMDSimulatorV2(
             output_dir=md_output_dir,

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/small_scale_docking.py
@@ -101,6 +101,10 @@ class SmallScaleDockingInputs(PosteraDockingWorkflowInputs):
     ml_scorers: Optional[list[str]] = Field(
         None, description="The name of the ml scorers to use"
     )
+    allow_dask_cuda: bool = Field(
+        True,
+        description="Whether to allow regenerating dask cuda cluster when in local mode",
+    )
 
     md: bool = Field(False, description="Whether to run MD on the docked poses")
     md_steps: PositiveInt = Field(2500000, description="Number of MD steps to run")
@@ -448,7 +452,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
     )
 
     if inputs.md:
-        if inputs.dask_type == DaskType.LOCAL:
+        if inputs.allow_dask_cuda and inputs.dask_type == DaskType.LOCAL_CPU:
             logger.info(
                 "Using local CPU dask cluster, and MD has been requested, replacing with a GPU cluster"
             )


### PR DESCRIPTION
## Description
Fixes #665 

Adds ability to run in a local-gpu dask mode, currently some issues around distributed and `dask_cuda` version pins meaning we are going to have to wait a bit to re-enable log forwarding. 

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
