### PR TITLE
fix alignment and long GIF

### DIFF
--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
@@ -41,7 +41,7 @@ class GIFVisualizerV2(BaseModel):
     static_view_only: bool = Field(
         False, description="Whether to only generate static views"
     )
-    start: PositiveInt = Field(1, description="Start frame")
+    start: PositiveInt = Field(1900, description="Start frame - if not defined, will default to last 10% of default trajectory settings")
     stop: int = Field(-1, description="Stop frame")
     interval: PositiveInt = Field(1, description="Interval between frames")
     debug: bool = Field(False, description="Whether to run in debug mode")
@@ -184,7 +184,9 @@ class GIFVisualizerV2(BaseModel):
                 # reload
                 complex_name_min = "complex_min"
                 p.cmd.load(str(system), object=complex_name_min)
-
+                p.cmd.align(complex_name, complex_name_min)
+                p.cmd.delete(complex_name_min)
+                
                 if self.smooth:
                     p.cmd.smooth(
                         "all", window=int(self.smooth)
@@ -214,8 +216,6 @@ class GIFVisualizerV2(BaseModel):
             if self.pse or self.pse_share:
                 p.cmd.save(str(out_dir / "session_5_selections.pse"))
 
-            p.cmd.align(complex_name, complex_name_min)
-            p.cmd.delete(complex_name_min)
             # Process the trajectory in a temporary directory
             from pygifsicle import gifsicle
 

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
@@ -42,7 +42,7 @@ class GIFVisualizerV2(BaseModel):
         False, description="Whether to only generate static views"
     )
     start: PositiveInt = Field(
-        1900,
+        1800,
         description="Start frame - if not defined, will default to last 10% of default trajectory settings",
     )
     stop: int = Field(-1, description="Stop frame")

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/viz_v2/gif_viz.py
@@ -41,7 +41,10 @@ class GIFVisualizerV2(BaseModel):
     static_view_only: bool = Field(
         False, description="Whether to only generate static views"
     )
-    start: PositiveInt = Field(1900, description="Start frame - if not defined, will default to last 10% of default trajectory settings")
+    start: PositiveInt = Field(
+        1900,
+        description="Start frame - if not defined, will default to last 10% of default trajectory settings",
+    )
     stop: int = Field(-1, description="Stop frame")
     interval: PositiveInt = Field(1, description="Interval between frames")
     debug: bool = Field(False, description="Whether to run in debug mode")
@@ -186,7 +189,7 @@ class GIFVisualizerV2(BaseModel):
                 p.cmd.load(str(system), object=complex_name_min)
                 p.cmd.align(complex_name, complex_name_min)
                 p.cmd.delete(complex_name_min)
-                
+
                 if self.smooth:
                     p.cmd.smooth(
                         "all", window=int(self.smooth)


### PR DESCRIPTION
Fixes two issues:

- ligand was not being aligned together with the protein, so was placed way outside of pocket by GIF viz. 
    -> done by jumping alignment step to just after loading trajectory instead of after application of centering etc
- hotfix for https://github.com/choderalab/asapdiscovery/issues/671, still need to make a more modular solution.
    -> done by adding a default value of `start` based on the default MD protocol

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
