### PR TITLE
change cross docking workflow to exclude all "similar" molecule pairs…

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/selectors/pairwise_selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/selectors/pairwise_selector.py
@@ -3,7 +3,7 @@ from itertools import product
 from typing import ClassVar, Union
 
 from asapdiscovery.data.schema_v2.complex import Complex, ComplexBase, PreppedComplex
-from asapdiscovery.data.schema_v2.ligand import Ligand
+from asapdiscovery.data.schema_v2.ligand import Ligand, ChemicalRelationship
 from asapdiscovery.data.schema_v2.pairs import CompoundStructurePair
 from asapdiscovery.data.selectors.selector import SelectorBase
 
@@ -60,6 +60,43 @@ class LeaveOneOutSelector(SelectorBase):
         for lig, complex in product(ligands, complexes):
             # Need to compare chemical identity instead of compound ID
             if not lig.inchi == complex.ligand.inchi:
+                pairs.append(pair_cls(complex=complex, ligand=lig))
+
+        return pairs
+
+    def provenance(self):
+        return {"selector": self.dict()}
+
+
+class LeaveSimilarOutSelector(SelectorBase):
+    """
+    Selects ligand and complex pairs by enumerating all possible pairs except any that are similar (including not just
+    identical ligands but also stereoisomers, protonation states, and tautomers).
+    """
+
+    selector_type: ClassVar[str] = "LeaveOneOutSelector"
+
+    def _select(
+        self, ligands: list[Ligand], complexes: list[Union[Complex, PreppedComplex]]
+    ) -> list[CompoundStructurePair]:
+        if not all(isinstance(c, ComplexBase) for c in complexes):
+            raise ValueError("All complexes must be of type Complex, or PreppedComplex")
+
+        if not all(isinstance(c, type(complexes[0])) for c in complexes):
+            raise ValueError("All complexes must be of the same type")
+
+        pair_cls = self._pair_type_from_complex(complexes[0])
+
+        pairs = []
+        for lig, complex in product(ligands, complexes):
+            # Need to compare chemical identity instead of compound ID
+            if (
+                lig.get_chemical_relationship(complex.ligand)
+                not in ChemicalRelationship.IDENTICAL
+                | ChemicalRelationship.STEREOISOMER
+                | ChemicalRelationship.TAUTOMER
+                | ChemicalRelationship.PROTONATION_STATE_ISOMER
+            ):
                 pairs.append(pair_cls(complex=complex, ligand=lig))
 
         return pairs

--- a/asapdiscovery-data/asapdiscovery/data/selectors/selector_list.py
+++ b/asapdiscovery-data/asapdiscovery/data/selectors/selector_list.py
@@ -6,12 +6,14 @@ from enum import Enum
 from asapdiscovery.data.selectors.mcs_selector import MCSSelector
 from asapdiscovery.data.selectors.pairwise_selector import (
     LeaveOneOutSelector,
+    LeaveSimilarOutSelector,
     PairwiseSelector,
     SelfDockingSelector,
 )
 
 _ALL_SELECTORS = {
     LeaveOneOutSelector.selector_type: LeaveOneOutSelector,
+    LeaveSimilarOutSelector.selector_type: LeaveSimilarOutSelector,
     PairwiseSelector.selector_type: PairwiseSelector,
     SelfDockingSelector.selector_type: SelfDockingSelector,
     MCSSelector.selector_type: MCSSelector,
@@ -26,6 +28,7 @@ class StructureSelector(str, Enum):
     MCS = MCSSelector.selector_type
     PAIRWISE = PairwiseSelector.selector_type
     LEAVE_ONE_OUT = LeaveOneOutSelector.selector_type
+    LEAVE_SIMILAR_OUT = LeaveSimilarOutSelector.selector_type
     SELF_DOCKING = SelfDockingSelector.selector_type
 
     @property

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
@@ -4,6 +4,7 @@ from asapdiscovery.data.schema_v2.pairs import CompoundStructurePair
 from asapdiscovery.data.selectors.mcs_selector import MCSSelector
 from asapdiscovery.data.selectors.pairwise_selector import (
     LeaveOneOutSelector,
+    LeaveSimilarOutSelector,
     PairwiseSelector,
     SelfDockingSelector,
 )
@@ -18,6 +19,12 @@ def test_pairwise_selector(ligands, complexes):
 
 def test_leave_one_out_selector(ligands, complexes):
     selector = LeaveOneOutSelector()
+    pairs = selector.select(ligands, complexes)
+    assert len(pairs) == 36
+
+
+def test_leave_similar_out_selector(ligands, complexes):
+    selector = LeaveSimilarOutSelector()
     pairs = selector.select(ligands, complexes)
     assert len(pairs) == 36
 

--- a/asapdiscovery-docking/asapdiscovery/docking/cli.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/cli.py
@@ -173,7 +173,7 @@ def large_scale(
 @click.option(
     "--structure-selector",
     type=click.Choice(StructureSelector.get_values(), case_sensitive=False),
-    default=StructureSelector.PAIRWISE,
+    default=StructureSelector.LEAVE_SIMILAR_OUT,
     help="The type of structure selector to use. Defaults to pairwise (all pairwise combinations of ligand and complex)",
 )
 @ligands
@@ -188,7 +188,7 @@ def large_scale(
 def cross_docking(
     target: TargetTags,
     multi_reference: bool = False,
-    structure_selector: StructureSelector = StructureSelector.PAIRWISE,
+    structure_selector: StructureSelector = StructureSelector.LEAVE_SIMILAR_OUT,
     use_omega: bool = False,
     omega_dense: bool = False,
     allow_retries: bool = False,

--- a/asapdiscovery-docking/asapdiscovery/docking/workflows/cross_docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/workflows/cross_docking.py
@@ -32,7 +32,7 @@ class CrossDockingWorkflowInputs(DockingWorkflowInputsBase):
     logname: str = Field("", description="Name of the log file.")
 
     structure_selector: StructureSelector = Field(
-        StructureSelector.PAIRWISE,
+        StructureSelector.LEAVE_SIMILAR_OUT,
         description="Structure selector to use for docking",
     )
     multi_reference: bool = Field(


### PR DESCRIPTION
…, not just the identical ones

## Description
Pretty straightforward. Kind of annoying the number of places I changed the default but not too bad.

## TODO
- [x] add selector
- [x] add selector to cross docking workflows
- [x] add tests

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
