### PR TITLE
Track the POSIT Method that was actually used during the docking

### DIFF
--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -294,8 +294,8 @@ class POSITDocker(DockingBase):
                         # set SD tags
                         sd_data = {
                             DockingResultCols.DOCKING_CONFIDENCE_POSIT.value: prob,
-                            DockingResultCols.POSIT_METHOD.value: POSIT_METHOD.reverse_lookup(
-                                self.posit_method.value
+                            DockingResultCols.POSIT_METHOD.value: oedocking.OEPositMethodGetName(
+                                result.GetPositMethod()
                             ),
                         }
                         posed_ligand.set_SD_data(sd_data)


### PR DESCRIPTION
## Description
Adds back the functionality from 
https://github.com/choderalab/asapdiscovery/blob/f83d4d206dcb96fbeca385b7f17b817db9a33734/asapdiscovery-docking/asapdiscovery/docking/docking.py#L286-L288

For instance, right now if you don't give POSIT any specifics we use the "ALL" method, and then the "ALL" method is saved in the SD tags. but it's actually more helpful if we record which sub-method was actually used (FRED / HYBRID / SHAPEFIT) etc.

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
