### PR TITLE
include date in cache key

### DIFF
--- a/.github/workflows/alchemy.yaml
+++ b/.github/workflows/alchemy.yaml
@@ -45,6 +45,9 @@ jobs:
         df -h
         ulimit -a
 
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
 
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/data.yaml
+++ b/.github/workflows/data.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/dataviz.yaml
+++ b/.github/workflows/dataviz.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/docking.yaml
+++ b/.github/workflows/docking.yaml
@@ -45,6 +45,10 @@ jobs:
         df -h
         ulimit -a
 
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     - name: Set Swap Space
       uses: pierotofy/set-swap-space@master
       with:
@@ -58,6 +62,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/macos-ci.yaml
+++ b/.github/workflows/macos-ci.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/ml.yaml
+++ b/.github/workflows/ml.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/modeling.yaml
+++ b/.github/workflows/modeling.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 

--- a/.github/workflows/simulation.yaml
+++ b/.github/workflows/simulation.yaml
@@ -45,7 +45,10 @@ jobs:
         df -h
         ulimit -a
 
-
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +%Y-%m-%d)" >> "${GITHUB_OUTPUT}"
+        
     # More info on options: https://github.com/mamba-org/provision-with-micromamba
     - name: Setup Conda Environment
       uses: mamba-org/setup-micromamba@v1
@@ -54,6 +57,8 @@ jobs:
         environment-name: asapdiscovery
         cache-environment: true
         cache-downloads: true
+        cache-environment-key: environment-${{ steps.date.outputs.date }}
+        cache-downloads-key: downloads-${{ steps.date.outputs.date }}
         create-args: >-
           python==${{ matrix.python-version }}
 


### PR DESCRIPTION
This adds the date in the cache key so that we only keep the env cache and package cache around for max 1 day. This will still speed things up a lot but ensures that our scheduled tests get a fresh env each day.

## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
