### PR TITLE
quick guardrail that uses SMILES in case no names are set for ligands

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -183,6 +183,13 @@ class AlchemiscaleHelper:
             # extract the names of the end state ligands to build the affinity estimate graph
             name_a = individual_runs[0][0].inputs["stateA"].components["ligand"].name
             name_b = individual_runs[0][0].inputs["stateB"].components["ligand"].name
+            print(individual_runs[0][0].inputs["stateB"].components["ligand"], name_b)
+
+            # if end state ligands did not have names, use SMILES instead
+            if not name_a:
+                name_a = individual_runs[0][0].inputs["stateA"].components["ligand"].smiles
+            if not name_b:
+                name_b = individual_runs[0][0].inputs["stateB"].components["ligand"].smiles
 
             results.append(
                 TransformationResult(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/utils.py
@@ -187,9 +187,13 @@ class AlchemiscaleHelper:
 
             # if end state ligands did not have names, use SMILES instead
             if not name_a:
-                name_a = individual_runs[0][0].inputs["stateA"].components["ligand"].smiles
+                name_a = (
+                    individual_runs[0][0].inputs["stateA"].components["ligand"].smiles
+                )
             if not name_b:
-                name_b = individual_runs[0][0].inputs["stateB"].components["ligand"].smiles
+                name_b = (
+                    individual_runs[0][0].inputs["stateB"].components["ligand"].smiles
+                )
 
             results.append(
                 TransformationResult(


### PR DESCRIPTION
## Description
adds a quick post-simulation guardrail that sets ligand SMILES as names in case no names are set to ligands in an `alchemiscale` network. 

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
