### PR TITLE
ASAP-Alchemy: status all

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -334,7 +334,6 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
     from asapdiscovery.alchemy.schema.fec import FreeEnergyCalculationNetwork
     from asapdiscovery.alchemy.utils import AlchemiscaleHelper
     from rich import pretty
-    from rich.padding import Padding
     from rich.table import Table
 
     pretty.install()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -307,7 +307,15 @@ def gather(network: str, allow_missing: bool):
     default=False,
     help="Output the errors and tracebacks from the failing tasks.",
 )
-def status(network: str, errors: bool, with_traceback: bool):
+@click.option(
+    "-a",
+    "--all-networks",
+    is_flag=True,
+    default=False,
+    help="If the status of all running tasks in your scope should be displayed. "
+         "This option will cause the command to ignore all other flags."
+)
+def status(network: str, errors: bool, with_traceback: bool, all_networks: bool):
     """
     Get the status of the submitted network on alchemiscale.\f
 
@@ -315,32 +323,80 @@ def status(network: str, errors: bool, with_traceback: bool):
         network: The name of the JSON file containing the FreeEnergyCalculationNetwork we should check the status of.
         errors: Flag to show errors from the tasks.
         with_traceback: Flag to show the complete traceback for the errored tasks.
+        all_networks: If that status of all networks under the users scope should be displayed rather than for a single network.
+
+    Notes:
+        The `all_networks` flag will ignore all other flags, to get error details for a specific network use the network argument.
 
     """
     from asapdiscovery.alchemy.schema.fec import FreeEnergyCalculationNetwork
     from asapdiscovery.alchemy.utils import AlchemiscaleHelper
+    from rich import pretty
+    from rich.padding import Padding
+    import rich
+    from asapdiscovery.alchemy.cli.utils import print_header
+    from rich.table import Table
+
+    pretty.install()
+    console = rich.get_console()
+    print_header(console)
 
     # launch the helper which will try to login
     client = AlchemiscaleHelper()
-    # load the network
-    planned_network = FreeEnergyCalculationNetwork.from_file(network)
-    # check the status
-    client.network_status(planned_network=planned_network)
-    # collect errors
-    if errors or with_traceback:
-        task_errors = client.collect_errors(
-            planned_network,
-        )
-        # output errors in readable format
-        for failure in task_errors:
-            click.echo(click.style("Task:", bold=True))
-            click.echo(f"{failure.task_key}")
-            click.echo(click.style("Error:", bold=True))
-            click.echo(f"{failure.error}")
-            if with_traceback:
-                click.echo(click.style("Traceback:", bold=True))
-                click.echo(f"{failure.traceback}")
-            click.echo()
+    if all_networks:
+        # show the results of all tasks in scope, this will print to terminal
+        client._client.get_scope_status()
+
+        # now get the status break down for each network in scope with running or waiting tasks only
+        running_networks = client._client.query_networks()
+
+        status_breakdown = console.status("Creating status breakdown")
+        status_breakdown.start()
+
+        # format into a rich table
+        table = Table()
+        table.add_column("Network Key", justify="center", no_wrap=True)
+        table.add_column("Complete", overflow="fold", style="green", header_style="green")
+        table.add_column("Running", overflow="fold", style="orange3", header_style="orange3")
+        table.add_column("Waiting", overflow="fold", style="#1793d0", header_style="#1793d0")
+        table.add_column("Error", overflow="fold", style="#ff073a", header_style="#ff073a")
+        table.add_column("Invalid", overflow="fold", style="magenta1", header_style="magenta1")
+        table.add_column("Deleted", overflow="fold", style="purple", header_style="purple")
+        for key in running_networks:
+            network_status = client._client.get_network_status(network=key, visualize=False)
+            if "running" in network_status or "waiting" in network_status:
+                table.add_row(
+                    str(key),
+                    str(network_status.get("complete", 0)),
+                    str(network_status.get("running", 0)),
+                    str(network_status.get("waiting", 0)),
+                    str(network_status.get("error", 0)),
+                    str(network_status.get("invalid", 0)),
+                    str(network_status.get("deleted", 0))
+                )
+        status_breakdown.stop()
+        console.print(table)
+
+    else:
+        # load the network
+        planned_network = FreeEnergyCalculationNetwork.from_file(network)
+        # check the status
+        client.network_status(planned_network=planned_network)
+        # collect errors
+        if errors or with_traceback:
+            task_errors = client.collect_errors(
+                planned_network,
+            )
+            # output errors in readable format
+            for failure in task_errors:
+                click.echo(click.style("Task:", bold=True))
+                click.echo(f"{failure.task_key}")
+                click.echo(click.style("Error:", bold=True))
+                click.echo(f"{failure.error}")
+                if with_traceback:
+                    click.echo(click.style("Traceback:", bold=True))
+                    click.echo(f"{failure.traceback}")
+                click.echo()
 
 
 @alchemy.command()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -313,7 +313,7 @@ def gather(network: str, allow_missing: bool):
     is_flag=True,
     default=False,
     help="If the status of all running tasks in your scope should be displayed. "
-         "This option will cause the command to ignore all other flags."
+    "This option will cause the command to ignore all other flags.",
 )
 def status(network: str, errors: bool, with_traceback: bool, all_networks: bool):
     """
@@ -329,12 +329,12 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
         The `all_networks` flag will ignore all other flags, to get error details for a specific network use the network argument.
 
     """
+    import rich
+    from asapdiscovery.alchemy.cli.utils import print_header
     from asapdiscovery.alchemy.schema.fec import FreeEnergyCalculationNetwork
     from asapdiscovery.alchemy.utils import AlchemiscaleHelper
     from rich import pretty
     from rich.padding import Padding
-    import rich
-    from asapdiscovery.alchemy.cli.utils import print_header
     from rich.table import Table
 
     pretty.install()
@@ -356,14 +356,28 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
         # format into a rich table
         table = Table()
         table.add_column("Network Key", justify="center", no_wrap=True)
-        table.add_column("Complete", overflow="fold", style="green", header_style="green")
-        table.add_column("Running", overflow="fold", style="orange3", header_style="orange3")
-        table.add_column("Waiting", overflow="fold", style="#1793d0", header_style="#1793d0")
-        table.add_column("Error", overflow="fold", style="#ff073a", header_style="#ff073a")
-        table.add_column("Invalid", overflow="fold", style="magenta1", header_style="magenta1")
-        table.add_column("Deleted", overflow="fold", style="purple", header_style="purple")
+        table.add_column(
+            "Complete", overflow="fold", style="green", header_style="green"
+        )
+        table.add_column(
+            "Running", overflow="fold", style="orange3", header_style="orange3"
+        )
+        table.add_column(
+            "Waiting", overflow="fold", style="#1793d0", header_style="#1793d0"
+        )
+        table.add_column(
+            "Error", overflow="fold", style="#ff073a", header_style="#ff073a"
+        )
+        table.add_column(
+            "Invalid", overflow="fold", style="magenta1", header_style="magenta1"
+        )
+        table.add_column(
+            "Deleted", overflow="fold", style="purple", header_style="purple"
+        )
         for key in running_networks:
-            network_status = client._client.get_network_status(network=key, visualize=False)
+            network_status = client._client.get_network_status(
+                network=key, visualize=False
+            )
             if "running" in network_status or "waiting" in network_status:
                 table.add_row(
                     str(key),
@@ -372,7 +386,7 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
                     str(network_status.get("waiting", 0)),
                     str(network_status.get("error", 0)),
                     str(network_status.get("invalid", 0)),
-                    str(network_status.get("deleted", 0))
+                    str(network_status.get("deleted", 0)),
                 )
         status_breakdown.stop()
         console.print(table)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -258,20 +258,27 @@ def test_alchemy_status_all(monkeypatch, alchemiscale_helper):
 
     def get_network_keys(*args, **kwargs):
         """Mock a network key for a running network"""
-        return [ScopedKey(gufe_key="fakenetwork", org="asap", campaign="alchemy", project="testing")]
+        return [
+            ScopedKey(
+                gufe_key="fakenetwork",
+                org="asap",
+                campaign="alchemy",
+                project="testing",
+            )
+        ]
 
     monkeypatch.setattr(AlchemiscaleClient, "_get_resource", _get_resource)
     monkeypatch.setattr(AlchemiscaleClient, "query_networks", get_network_keys)
 
     runner = CliRunner()
 
-    result = runner.invoke(
-        alchemy,
-        [
-            "status",
-            "-a"
-        ]
-    )
+    result = runner.invoke(alchemy, ["status", "-a"])
     assert result.exit_code == 0
-    assert "complete                                     │                             1 " in result.stdout
-    assert "│ fakenetwork-asap-alchemy-testing │ 1    │ 2    │ 3     │ 0    │ 0     │ 0    │" in result.stdout
+    assert (
+        "complete                                     │                             1 "
+        in result.stdout
+    )
+    assert (
+        "│ fakenetwork-asap-alchemy-testing │ 1    │ 2    │ 3     │ 0    │ 0     │ 0    │"
+        in result.stdout
+    )

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -245,3 +245,33 @@ def test_alchemy_prep_run_all_pass(tmpdir, mac1_complex):
         assert len(prep_dataset.input_ligands) == 5
         assert len(prep_dataset.posed_ligands) == 5
         assert prep_dataset.failed_ligands is None
+
+
+def test_alchemy_status_all(monkeypatch, alchemiscale_helper):
+    """Mock testing the status all command."""
+
+    from alchemiscale import AlchemiscaleClient
+    from alchemiscale.models import ScopedKey
+
+    def _get_resource(*args, **kwargs):
+        return {"complete": 1, "running": 2, "waiting": 3}
+
+    def get_network_keys(*args, **kwargs):
+        """Mock a network key for a running network"""
+        return [ScopedKey(gufe_key="fakenetwork", org="asap", campaign="alchemy", project="testing")]
+
+    monkeypatch.setattr(AlchemiscaleClient, "_get_resource", _get_resource)
+    monkeypatch.setattr(AlchemiscaleClient, "query_networks", get_network_keys)
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        alchemy,
+        [
+            "status",
+            "-a"
+        ]
+    )
+    assert result.exit_code == 0
+    assert "complete                                     │                             1 " in result.stdout
+    assert "│ fakenetwork-asap-alchemy-testing │ 1    │ 2    │ 3     │ 0    │ 0     │ 0    │" in result.stdout


### PR DESCRIPTION
## Description
this PR extends the ASAP-Alchemy status command with a flag to view the status of all networks in the users scope and provides a detailed breakdown of the status per network to help with #712.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add a test for the flag

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
