### PR TITLE
Remove oe version specific provenance testing

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
@@ -42,21 +42,13 @@ def test_prep_workflow(strict_stereo, core_smarts, failed, mac1_complex):
     )
 
     assert len(alchemy_dataset.input_ligands) == 1
-    assert alchemy_dataset.provenance == {
-        "OpenEyeConstrainedPoseGenerator": {
-            "oechem": 20230910,
-            "oedocking": 20230910,
-            "oeff": 20230910,
-            "oeomega": 20230910,
-        },
-        "StereoExpander": {
-            "expander": {
-                "expander_type": "StereoExpander",
-                "stereo_expand_defined": False,
-            },
-            "oechem": 20230910,
-            "omega": 20230910,
-        },
+    assert alchemy_dataset.provenance.keys() == [
+        "OpenEyeConstrainedPoseGenerator",
+        "StereoExpander",
+    ]
+    assert alchemy_dataset.provenance["StereoExpander"]["expander"] == {
+        "expander_type": "StereoExpander",
+        "stereo_expand_defined": False,
     }
     if failed:
         assert len(alchemy_dataset.posed_ligands) == 0

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
@@ -42,10 +42,10 @@ def test_prep_workflow(strict_stereo, core_smarts, failed, mac1_complex):
     )
 
     assert len(alchemy_dataset.input_ligands) == 1
-    assert list(alchemy_dataset.provenance.keys()) == [
+    assert set(alchemy_dataset.provenance.keys()) == {
         "OpenEyeConstrainedPoseGenerator",
         "StereoExpander",
-    ]
+    }
     assert alchemy_dataset.provenance["StereoExpander"]["expander"] == {
         "expander_type": "StereoExpander",
         "stereo_expand_defined": False,

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_alchemy_prep.py
@@ -42,7 +42,7 @@ def test_prep_workflow(strict_stereo, core_smarts, failed, mac1_complex):
     )
 
     assert len(alchemy_dataset.input_ligands) == 1
-    assert alchemy_dataset.provenance.keys() == [
+    assert list(alchemy_dataset.provenance.keys()) == [
         "OpenEyeConstrainedPoseGenerator",
         "StereoExpander",
     ]


### PR DESCRIPTION
## Description
Fixes #761 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Remove OE provenance from asap alchemy tests

## Questions
- [x] I did the inverse of popping but hopefully this is good enough?

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
