### PR TITLE
fix trainer param gradient handling

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/schema_v2/trainer.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/schema_v2/trainer.py
@@ -593,7 +593,13 @@ class Trainer(BaseModel):
             if batch_counter > 0:
                 # Backprop for final incomplete batch
                 self.optimizer.step()
-                if any([p.grad.isnan().any().item() for p in self.model.parameters()]):
+                if any(
+                    [
+                        p.grad.isnan().any().item()
+                        for p in self.model.parameters()
+                        if p.grad is not None
+                    ]
+                ):
                     raise ValueError("NaN gradients")
             end_time = time()
 


### PR DESCRIPTION
## Description
When the last batch is incomplete, `trainer()`should check if parameters have gradient before checking for NaN gradients.

Fix #804

## Status
- [ ] Ready to go

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
