### PR TITLE
Add MTENN version check

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
@@ -51,6 +51,8 @@ asapdiscovery-GAT-2023.04.12:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # asapdiscovery-GAT-2023.04.20 model

--- a/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
+++ b/asapdiscovery-ml/asapdiscovery/ml/asap_models.yaml
@@ -29,6 +29,12 @@ gat_test_v0:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  # Because model compatibility with mtenn versions changes over time, the below pins
+  #  will make sure the model spec is compatible with the installed mtenn version.
+  #  Versions will be checked as:
+  #   `mtenn_lower_pin <= mtenn.__version__ < mtenn_upper_pin`
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # asapdiscovery-GAT-2023.04.12 model
@@ -61,6 +67,8 @@ asapdiscovery-GAT-2023.04.20:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # asapdiscovery-schnet-2023.04.29 model
@@ -77,6 +85,8 @@ asapdiscovery-schnet-2023.04.29:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # Earlier models will not work with DGL >1.1 due to changes in their code
@@ -94,6 +104,8 @@ asapdiscovery-GAT-2023.05.09:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # ! From here on we will prefix the model names with targets as there are now models for each target
@@ -112,6 +124,8 @@ asapdiscovery-SARS-CoV-2-Mpro-GAT-2023.08.09:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # same as asapdiscovery-schnet-2023.04.29
@@ -128,6 +142,8 @@ asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.04.29:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # asapdiscovery-SARS-CoV-2-Mac1-GAT-2023.08.09 !! First Mac1 model
@@ -143,6 +159,8 @@ asapdiscovery-SARS-CoV-2-Mac1-GAT-2023.08.09:
   last_updated: 2023-08-09
   targets:
     - SARS-CoV-2-Mac1
+  mtenn_lower_pin: "0.0.0"
+  mtenn_upper_pin: "0.3.0"
 
 
 # earlier SchNet models shouldn't be used with mtenn >0.3.0 (GAT models should be fine,
@@ -160,6 +178,8 @@ asapdiscovery-SARS-CoV-2-Mpro-GAT-2023.08.25:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.3.0"
+  mtenn_upper_pin:
 
 
 asapdiscovery-SARS-CoV-2-Mac1-GAT-2023.08.25:
@@ -174,6 +194,8 @@ asapdiscovery-SARS-CoV-2-Mac1-GAT-2023.08.25:
   last_updated: 2023-08-25
   targets:
     - SARS-CoV-2-Mac1
+  mtenn_lower_pin: "0.3.0"
+  mtenn_upper_pin:
 
 
 asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.08.25:
@@ -189,6 +211,8 @@ asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.08.25:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.3.0"
+  mtenn_upper_pin:
 
 
 # new SchNet model trained with a lower learning rate to avoid the weights collapsing
@@ -206,3 +230,5 @@ asapdiscovery-SARS-CoV-2-Mpro-schnet-2023.11.20:
   targets:
     - SARS-CoV-2-Mpro
     - MERS-CoV-Mpro
+  mtenn_lower_pin: "0.3.0"
+  mtenn_upper_pin:

--- a/asapdiscovery-ml/asapdiscovery/ml/inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/inference.py
@@ -15,6 +15,8 @@ from asapdiscovery.ml.models import (
     MLModelSpec,
 )
 
+import mtenn
+
 # static import of models from base yaml here
 from asapdiscovery.ml.utils import build_model, load_weights
 from dgllife.utils import CanonicalAtomFeaturizer
@@ -142,6 +144,27 @@ class InferenceBase(BaseModel):
         InferenceBase
             InferenceBase object created from LocalMLModelSpec.
         """
+
+        # First make sure mtenn versions are compatible
+        if not local_model_spec.check_mtenn_version():
+            lower_pin = (
+                f">={local_model_spec.mtenn_lower_pin}"
+                if local_model_spec.mtenn_lower_pin
+                else ""
+            )
+            upper_pin = (
+                f"<{local_model_spec.mtenn_upper_pin}"
+                if local_model_spec.mtenn_upper_pin
+                else ""
+            )
+            sep = "," if lower_pin and upper_pin else ""
+
+            raise ValueError(
+                f"Installed mtenn version ({mtenn.__version__}) "
+                "is incompatible with the version specified in the MLModelSpec "
+                f"({lower_pin}{sep}{upper_pin})"
+            )
+
         model = build_model(
             local_model_spec.type,
             config=local_model_spec.config_file,

--- a/asapdiscovery-ml/asapdiscovery/ml/inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/inference.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Union  # noqa: F401
 
 import dgl
+import mtenn
 import numpy as np
 import torch
 from asapdiscovery.data.openeye import oechem
@@ -14,8 +15,6 @@ from asapdiscovery.ml.models import (
     MLModelRegistry,
     MLModelSpec,
 )
-
-import mtenn
 
 # static import of models from base yaml here
 from asapdiscovery.ml.utils import build_model, load_weights

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_inference.py
@@ -25,13 +25,17 @@ def test_gatinference_construct_by_latest(target):
 def test_gatinference_construct_from_name(
     tmp_path,
 ):
-    inference_cls = GATInference.from_model_name("gat_test_v0", local_dir=tmp_path)
+    inference_cls = GATInference.from_model_name(
+        "asapdiscovery-SARS-CoV-2-Mpro-GAT-2023.08.25", local_dir=tmp_path
+    )
     assert inference_cls is not None
     assert inference_cls.local_model_spec.local_dir == tmp_path
 
 
 def test_gatinference_predict(test_data):
-    inference_cls = GATInference.from_model_name("gat_test_v0")
+    inference_cls = GATInference.from_model_name(
+        "asapdiscovery-SARS-CoV-2-Mpro-GAT-2023.08.25"
+    )
     g1, _, _, _ = test_data
     assert inference_cls is not None
     output = inference_cls.predict(g1)

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -31,6 +31,7 @@ dependencies:
   - pebble
   - panel
   - plotmol
+  - semver
 
   # data
   - requests

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -31,6 +31,7 @@ dependencies:
   - pebble
   - panel
   - plotmol
+  - semver
 
   # data
   - requests


### PR DESCRIPTION
`mtenn` models will only work with certain versions of the package, so add pins in `asapdiscovery.ml.models.MLModelBase` to check and make sure versions are compatible. Fixes #532.