### PR TITLE
ASAP-Alchemy: Allow Postera molecule sets as input

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -98,7 +98,7 @@ def run(
     factory_file: Optional[str] = None,
     core_smarts: Optional[str] = None,
     processors: int = 1,
-    postera_molset_name: Optional[str] = None
+    postera_molset_name: Optional[str] = None,
 ):
     """
     Create an AlchemyDataset by running the given AlchemyPrepWorkflow which will expand the ligand states and generate
@@ -142,7 +142,9 @@ def run(
 
     # workout where the molecules are coming from
     if postera_molset_name is not None:
-        postera_download = console.status(f"Downloading molecules from Postera molecule set:{postera_molset_name}")
+        postera_download = console.status(
+            f"Downloading molecules from Postera molecule set:{postera_molset_name}"
+        )
         postera_download.start()
         asap_ligands = pull_from_postera(molecule_set_name=postera_molset_name)
         postera_download.stop()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -2,7 +2,7 @@ import rich
 
 
 def print_header(console: "rich.Console"):
-    "Print an ASAP-Alchemy header"
+    """Print an ASAP-Alchemy header"""
 
     console.line()
     console.rule("ASAP-Alchemy")
@@ -11,10 +11,12 @@ def print_header(console: "rich.Console"):
 
 def pull_from_postera(molecule_set_name: str):
     """
-    A convenience method with tucked imports to avoid import Postera tools when not needed.
+    A convenience method with tucked imports to avoid importing Postera tools when not needed.
 
-    Returns
-    -------
+    Args:
+        The name of the molecule set which should be pulled from postera
+
+    Returns:
         A list of Ligands extracted from postera molecule set.
     """
     from asapdiscovery.data.services_config import PosteraSettings

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -19,8 +19,8 @@ def pull_from_postera(molecule_set_name: str):
     Returns:
         A list of Ligands extracted from postera molecule set.
     """
-    from asapdiscovery.data.services_config import PosteraSettings
     from asapdiscovery.data.postera.postera_factory import PosteraFactory
+    from asapdiscovery.data.services_config import PosteraSettings
 
     # this will pull the settings from environment variables
     settings = PosteraSettings()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -7,3 +7,19 @@ def print_header(console: "rich.Console"):
     console.line()
     console.rule("ASAP-Alchemy")
     console.line()
+
+
+def pull_from_postera(molecule_set_name: str):
+    """
+    A convenience method with tucked imports to avoid import Postera tools when not needed.
+
+    Returns
+    -------
+        A list of Ligands extracted from postera molecule set.
+    """
+    from asapdiscovery.data.services_config import PosteraSettings
+    from asapdiscovery.data.postera.postera_factory import PosteraFactory
+
+    # this will pull the settings from environment variables
+    settings = PosteraSettings()
+    return PosteraFactory(settings=settings, molecule_set_name=molecule_set_name).pull()

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -257,7 +257,9 @@ def test_alchemy_prep_run_all_pass(tmpdir, mac1_complex, openeye_prep_workflow):
         assert prep_dataset.failed_ligands is None
 
 
-def test_alchemy_prep_run_from_postera(tmpdir, mac1_complex, openeye_prep_workflow, monkeypatch):
+def test_alchemy_prep_run_from_postera(
+    tmpdir, mac1_complex, openeye_prep_workflow, monkeypatch
+):
     """Test running the alchemy prep workflow on a set of mac1 ligands downloaded from postera."""
     from asapdiscovery.alchemy.cli import utils
     from asapdiscovery.data.schema_v2.ligand import Ligand
@@ -270,6 +272,7 @@ def test_alchemy_prep_run_from_postera(tmpdir, mac1_complex, openeye_prep_workfl
     def pull(molecule_set_name: str) -> list[Ligand]:
         assert molecule_set_name == "mac1_ligands"
         return MolFileFactory(filename=ligand_file.as_posix()).load()
+
     monkeypatch.setattr(utils, "pull_from_postera", pull)
 
     runner = CliRunner()


### PR DESCRIPTION
## Description
This PR extends the ASAP-Alchemy prep CLI to take in postera molecule sets as input.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [X] tests

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
