### PR TITLE
ASAP-Alchemy: Save failed pose generation molecules to csv

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -200,8 +200,10 @@ def run(
     if alchemy_dataset.failed_ligands:
         rows = []
         failed_ligands_file = output_folder.joinpath("failed_ligands.csv")
+        # sum all the failed ligands across all stages
+        fails = sum([len(values) for values in alchemy_dataset.failed_ligands.values()])
         message = Padding(
-            f"[yellow]WARNING some ligands failed to have poses generated see [repr.filename]{failed_ligands_file}[/repr.filename][/yellow]",
+            f"[yellow]WARNING {fails} ligands failed to have poses generated see [repr.filename]{failed_ligands_file}[/repr.filename][/yellow]",
             (1, 0, 1, 0),
         )
         console.print(message)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -109,12 +109,12 @@ def run(
     import pathlib
     from multiprocessing import cpu_count
 
+    import pandas
     import rich
     from asapdiscovery.alchemy.cli.utils import print_header
     from asapdiscovery.alchemy.schema.prep_workflow import AlchemyPrepWorkflow
     from asapdiscovery.data.schema_v2.complex import PreppedComplex
     from asapdiscovery.data.schema_v2.molfile import MolFileFactory
-    import pandas
     from rich import pretty
     from rich.padding import Padding
 
@@ -207,13 +207,15 @@ def run(
         console.print(message)
         for fail_type, ligands in alchemy_dataset.failed_ligands.items():
             for ligand in ligands:
-                rows.append({
-                    "smiles": ligand.provenance.isomeric_smiles,
-                    "name": ligand.compound_name,
-                    "failure type": fail_type,
-                    # if it was an omega fail print the return code
-                    "failure info": ligand.tags.get("omega_return_code", "")
-                })
+                rows.append(
+                    {
+                        "smiles": ligand.provenance.isomeric_smiles,
+                        "name": ligand.compound_name,
+                        "failure type": fail_type,
+                        # if it was an omega fail print the return code
+                        "failure info": ligand.tags.get("omega_return_code", ""),
+                    }
+                )
 
         # write to csv
         df = pandas.DataFrame(rows)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -168,10 +168,7 @@ def test_alchemy_prep_run_with_fails(tmpdir, mac1_complex, openeye_prep_workflow
             in result.stdout
         )
         # check a warning is printed if some molecules are removed
-        assert (
-            "WARNING some ligands failed to have poses generated"
-            in result.stdout
-        )
+        assert "WARNING some ligands failed to have poses generated" in result.stdout
         # check we can load the result
         prep_dataset = AlchemyDataSet.from_file(
             "mac1-testing/prepared_alchemy_dataset.json"
@@ -183,7 +180,11 @@ def test_alchemy_prep_run_with_fails(tmpdir, mac1_complex, openeye_prep_workflow
             .exists()
         )
         # make sure the csv of failed ligands is writen to file
-        assert pathlib.Path(prep_dataset.dataset_name).joinpath("failed_ligands.csv").exists()
+        assert (
+            pathlib.Path(prep_dataset.dataset_name)
+            .joinpath("failed_ligands.csv")
+            .exists()
+        )
         # check the dataset details are as expected
         assert prep_dataset.dataset_name == "mac1-testing"
         assert len(prep_dataset.input_ligands) == 5

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -169,7 +169,7 @@ def test_alchemy_prep_run_with_fails(tmpdir, mac1_complex, openeye_prep_workflow
         )
         # check a warning is printed if some molecules are removed
         assert (
-            "WARNING some ligands failed to have poses generated see failed_ligands"
+            "WARNING some ligands failed to have poses generated"
             in result.stdout
         )
         # check we can load the result
@@ -182,6 +182,9 @@ def test_alchemy_prep_run_with_fails(tmpdir, mac1_complex, openeye_prep_workflow
             .joinpath(f"{prep_dataset.reference_complex.target.target_name}.pdb")
             .exists()
         )
+        # make sure the csv of failed ligands is writen to file
+        assert pathlib.Path(prep_dataset.dataset_name).joinpath("failed_ligands.csv").exists()
+        # check the dataset details are as expected
         assert prep_dataset.dataset_name == "mac1-testing"
         assert len(prep_dataset.input_ligands) == 5
         assert len(prep_dataset.posed_ligands) == 3

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -168,7 +168,7 @@ def test_alchemy_prep_run_with_fails(tmpdir, mac1_complex, openeye_prep_workflow
             in result.stdout
         )
         # check a warning is printed if some molecules are removed
-        assert "WARNING some ligands failed to have poses generated" in result.stdout
+        assert "WARNING 2 ligands failed to have poses generated" in result.stdout
         # check we can load the result
         prep_dataset = AlchemyDataSet.from_file(
             "mac1-testing/prepared_alchemy_dataset.json"
@@ -242,7 +242,7 @@ def test_alchemy_prep_run_all_pass(tmpdir, mac1_complex, openeye_prep_workflow):
         assert "[✓] Stereochemistry filtering complete" not in result.stdout
         # check the failure warning is not printed
         assert (
-            "WARNING some ligands failed to have poses generated see failed_ligands"
+            "WARNING 2 ligands failed to have poses generated see failed_ligands"
             not in result.stdout
         )
         # check we can load the result


### PR DESCRIPTION
## Description
This PR improves the reporting of molecules which fail to have poses generated during `asap-alchemy prep run`. The molecules are saved to a csv file with their identifiers and information on why they might have failed rather than 2D molecules saved to an sdf. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] tests

## Questions
- [ ] What to use as an Id if the molecule has no compound name, is this possible?

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
