### PR TITLE
Cast UUIDs to str rather than UUID in identifiers

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -1,5 +1,6 @@
 from typing import Optional, Union
 from uuid import UUID
+
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
 from pydantic import Field, validator

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -1,8 +1,8 @@
-from typing import Optional
-
+from typing import Optional, Union
+from uuid import UUID
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from pydantic import Field
+from pydantic import Field, validator
 
 
 class LigandIdentifiers(DataModelAbstractBase):
@@ -26,18 +26,28 @@ class LigandIdentifiers(DataModelAbstractBase):
     moonshot_compound_id: Optional[str] = Field(
         None, description="Moonshot compound ID"
     )
-    manifold_api_id: Optional[str] = Field(
+    manifold_api_id: Optional[Union[UUID, str]] = Field(
         None, description="Unique ID from Postera Manifold API"
     )
     manifold_vc_id: Optional[str] = Field(
         None, description="Unique VC ID (virtual compound ID) from Postera Manifold"
     )
-    compchem_id: Optional[str] = Field(
+    compchem_id: Optional[Union[UUID, str]] = Field(
         None, description="Unique ID for P5 compchem reference, unused for now"
     )
 
     class Config:
         allow_mutation = False
+
+    @validator("manifold_api_id", "compchem_id", pre=True)
+    def cast_uuids(cls, v):
+        """
+        Cast UUIDS to string
+        """
+        if v is None:
+            return None
+        else:
+            return str(v)
 
 
 class LigandProvenance(DataModelAbstractBase):

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -1,5 +1,4 @@
-from typing import Optional, Union
-from uuid import UUID
+from typing import Optional
 
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -1,5 +1,4 @@
 from typing import Optional
-from uuid import UUID
 
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 from asapdiscovery.data.schema.schema_base import DataModelAbstractBase
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from pydantic import UUID4, Field
+from pydantic import Field
 
 
 class LigandIdentifiers(DataModelAbstractBase):
@@ -27,13 +27,13 @@ class LigandIdentifiers(DataModelAbstractBase):
     moonshot_compound_id: Optional[str] = Field(
         None, description="Moonshot compound ID"
     )
-    manifold_api_id: Optional[UUID] = Field(
+    manifold_api_id: Optional[str] = Field(
         None, description="Unique ID from Postera Manifold API"
     )
     manifold_vc_id: Optional[str] = Field(
         None, description="Unique VC ID (virtual compound ID) from Postera Manifold"
     )
-    compchem_id: Optional[UUID4] = Field(
+    compchem_id: Optional[str] = Field(
         None, description="Unique ID for P5 compchem reference, unused for now"
     )
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/identifiers.py
@@ -26,13 +26,13 @@ class LigandIdentifiers(DataModelAbstractBase):
     moonshot_compound_id: Optional[str] = Field(
         None, description="Moonshot compound ID"
     )
-    manifold_api_id: Optional[Union[UUID, str]] = Field(
+    manifold_api_id: Optional[str] = Field(
         None, description="Unique ID from Postera Manifold API"
     )
     manifold_vc_id: Optional[str] = Field(
         None, description="Unique VC ID (virtual compound ID) from Postera Manifold"
     )
-    compchem_id: Optional[Union[UUID, str]] = Field(
+    compchem_id: Optional[str] = Field(
         None, description="Unique ID for P5 compchem reference, unused for now"
     )
 

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
@@ -94,6 +94,7 @@ def test_ligand_ids_json_roundtrip():
     )
     ids2 = LigandIdentifiers.from_json(ids.json())
     assert ids == ids2
+    assert isinstance(ids2.manifold_api_id, str)
 
 
 def test_ligand_ids_json_file_roundtrip(tmp_path):


### PR DESCRIPTION
## Description
UUIDs cannot be serialised in Alchemy schema, so we should downcast to str

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
