### PR TITLE
ASAP-Alchemy: Postera uploading

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -653,13 +653,13 @@ def predict(
 
     # workout if we should upload to postera
     if bio_target is not None and postera_molset_name is not None:
-        # format and upload to posteara
+        # format and upload to postera
         postera_status = console.status(
             f"Uploading predictions to Postera Manifold molecule set: {postera_molset_name}."
         )
         postera_status.start()
 
-        _ = upload_to_postera(
+        upload_to_postera(
             molecule_set_name=postera_molset_name,
             target=target,
             absolute_dg_predictions=absolute_df,
@@ -670,6 +670,14 @@ def predict(
             (1, 0, 1, 0),
         )
         postera_status.stop()
+        console.print(message)
+
+    elif postera_molset_name is not None and bio_target is None:
+        message = Padding(
+            f"[yellow]WARNING a postera molecule set name was provided without a target, results will not be uploaded! "
+            f"Please run again and provide a valid target `-t`[/yellow]",
+            (1, 0, 1, 0)
+        )
         console.print(message)
 
     # workout if any reference data was provided and if we should create the interactive reports

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -1,7 +1,10 @@
 from typing import Optional
 
 import click
-from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags, TagEnumBase
+from asapdiscovery.data.services.postera.manifold_data_validation import (
+    TagEnumBase,
+    TargetTags,
+)
 
 
 @click.group()
@@ -87,7 +90,7 @@ def plan(
     factory_file: Optional[str] = None,
     alchemy_dataset: Optional[str] = None,
     experimental_protocol: Optional[str] = None,
-    target: Optional[TagEnumBase] = None
+    target: Optional[TagEnumBase] = None,
 ):
     """
     Plan a FreeEnergyCalculationNetwork using the given factory and inputs. The planned network will be written to file
@@ -153,7 +156,7 @@ def plan(
         ligands=input_ligands,
         central_ligand=center_ligand,
         experimental_protocol=experimental_protocol,
-        target=target
+        target=target,
     )
     click.echo(f"Writing results to {name}")
     # output the data to a folder named after the dataset
@@ -576,7 +579,7 @@ def predict(
     reference_dataset: Optional[str] = None,
     experimental_protocol: Optional[str] = None,
     target: Optional[TagEnumBase] = None,
-    postera_molset_name: Optional[str] = None
+    postera_molset_name: Optional[str] = None,
 ):
     """
     Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the
@@ -651,18 +654,20 @@ def predict(
     # workout if we should upload to postera
     if bio_target is not None and postera_molset_name is not None:
         # format and upload to posteara
-        postera_status = console.status(f"Uploading predictions to Postera Manifold molecule set: {postera_molset_name}.")
+        postera_status = console.status(
+            f"Uploading predictions to Postera Manifold molecule set: {postera_molset_name}."
+        )
         postera_status.start()
 
         _ = upload_to_postera(
             molecule_set_name=postera_molset_name,
             target=target,
-            absolute_dg_predictions=absolute_df
+            absolute_dg_predictions=absolute_df,
         )
 
         message = Padding(
             f"Predictions uploaded to Postera Manifold molecule set: {postera_molset_name}",
-            (1, 0, 1, 0)
+            (1, 0, 1, 0),
         )
         postera_status.stop()
         console.print(message)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -674,8 +674,8 @@ def predict(
 
     elif postera_molset_name is not None and bio_target is None:
         message = Padding(
-            f"[yellow]WARNING a postera molecule set name was provided without a target, results will not be uploaded! "
-            f"Please run again and provide a valid target `-t`[/yellow]",
+            "[yellow]WARNING a postera molecule set name was provided without a target, results will not be uploaded! "
+            "Please run again and provide a valid target `-t`[/yellow]",
             (1, 0, 1, 0),
         )
         console.print(message)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -676,7 +676,7 @@ def predict(
         message = Padding(
             f"[yellow]WARNING a postera molecule set name was provided without a target, results will not be uploaded! "
             f"Please run again and provide a valid target `-t`[/yellow]",
-            (1, 0, 1, 0)
+            (1, 0, 1, 0),
         )
         console.print(message)
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -28,7 +28,9 @@ def pull_from_postera(molecule_set_name: str):
     return PosteraFactory(settings=settings, molecule_set_name=molecule_set_name).pull()
 
 
-def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictions: pd.DataFrame) -> bool:
+def upload_to_postera(
+    molecule_set_name: str, target: str, absolute_dg_predictions: pd.DataFrame
+) -> bool:
     """
     A convenience method to format predicted absolute DG values using Alchemy and upload to postera with tucked imports
     to avoid importing Postera tools.
@@ -41,11 +43,14 @@ def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictio
     Returns:
         `True` if a new molecule set was made else `False` if we just update an existing set.
     """
+    from enum import Enum
+
+    from asapdiscovery.alchemy.predict import dg_to_postera_dataframe
+    from asapdiscovery.data.services.postera.manifold_data_validation import (
+        rename_output_columns_for_manifold,
+    )
     from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
     from asapdiscovery.data.services.services_config import PosteraSettings
-    from asapdiscovery.alchemy.predict import dg_to_postera_dataframe
-    from asapdiscovery.data.services.postera.manifold_data_validation import rename_output_columns_for_manifold
-    from enum import Enum
 
     # mock some enum to specifiy which columns are allowed?
     class AlchemyResults(str, Enum):
@@ -53,7 +58,9 @@ def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictio
         INCHI_KEY = "Inchi_Key"
         LIGAND_ID = "Ligand_ID"
         COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-biochemical-activity-FEC"
-        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = "computed-biochemical-activity-FEC-uncertainty"
+        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = (
+            "computed-biochemical-activity-FEC-uncertainty"
+        )
 
     # convert the dg values to pIC50 with the expected names
     postera_df = dg_to_postera_dataframe(absolute_predictions=absolute_dg_predictions)
@@ -66,7 +73,7 @@ def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictio
         allow=[
             AlchemyResults.SMILES.value,
             AlchemyResults.INCHI_KEY.value,
-            AlchemyResults.LIGAND_ID.value
+            AlchemyResults.LIGAND_ID.value,
         ],
     )
 
@@ -74,7 +81,7 @@ def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictio
         settings=PosteraSettings(),
         molecule_set_name=molecule_set_name,
         id_field=AlchemyResults.LIGAND_ID.value,
-        smiles_field=AlchemyResults.SMILES.value
+        smiles_field=AlchemyResults.SMILES.value,
     )
 
     _, _, made_new_molset = postera_uploader.push(result_df)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -54,9 +54,9 @@ def upload_to_postera(
         SMILES = "SMILES"
         INCHI_KEY = "Inchi_Key"
         LIGAND_ID = "Ligand_ID"
-        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-biochemical-activity-FEC"
+        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-FEC-pIC50"
         COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = (
-            "computed-biochemical-activity-FEC-uncertainty"
+            "computed-FEC-uncertainty-pIC50"
         )
 
     # convert the dg values to pIC50 with the expected names
@@ -81,4 +81,4 @@ def upload_to_postera(
         smiles_field=AlchemyResults.SMILES.value,
     )
 
-    _, _, _ = postera_uploader.push(result_df)
+    _, _, _ = postera_uploader.push(df=result_df)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -52,7 +52,6 @@ def upload_to_postera(
     # mock an enum to specify which columns are allowed
     class AlchemyResults(str, Enum):
         SMILES = "SMILES"
-        INCHI_KEY = "Inchi_Key"
         LIGAND_ID = "Ligand_ID"
         COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-FEC-pIC50"
         COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = "computed-FEC-uncertainty-pIC50"
@@ -67,7 +66,6 @@ def upload_to_postera(
         drop_non_output=True,
         allow=[
             AlchemyResults.SMILES.value,
-            AlchemyResults.INCHI_KEY.value,
             AlchemyResults.LIGAND_ID.value,
         ],
     )

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import rich
 
 
@@ -25,3 +26,57 @@ def pull_from_postera(molecule_set_name: str):
     # this will pull the settings from environment variables
     settings = PosteraSettings()
     return PosteraFactory(settings=settings, molecule_set_name=molecule_set_name).pull()
+
+
+def upload_to_postera(molecule_set_name: str, target: str, absolute_dg_predictions: pd.DataFrame) -> bool:
+    """
+    A convenience method to format predicted absolute DG values using Alchemy and upload to postera with tucked imports
+    to avoid importing Postera tools.
+
+    Args:
+        molecule_set_name: The name of the molecule set in postera the results should be attached to.
+        target: The name of the biological target this result is associated with.
+        absolute_dg_predictions: The dataset of absolute dg predictions created by asap-alchemy.
+
+    Returns:
+        `True` if a new molecule set was made else `False` if we just update an existing set.
+    """
+    from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
+    from asapdiscovery.data.services.services_config import PosteraSettings
+    from asapdiscovery.alchemy.predict import dg_to_postera_dataframe
+    from asapdiscovery.data.services.postera.manifold_data_validation import rename_output_columns_for_manifold
+    from enum import Enum
+
+    # mock some enum to specifiy which columns are allowed?
+    class AlchemyResults(str, Enum):
+        SMILES = "SMILES"
+        INCHI_KEY = "Inchi_Key"
+        LIGAND_ID = "Ligand_ID"
+        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-biochemical-activity-FEC"
+        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = "computed-biochemical-activity-FEC-uncertainty"
+
+    # convert the dg values to pIC50 with the expected names
+    postera_df = dg_to_postera_dataframe(absolute_predictions=absolute_dg_predictions)
+    result_df = rename_output_columns_for_manifold(
+        df=postera_df,
+        target=target,
+        output_enums=[AlchemyResults],
+        manifold_validate=True,
+        drop_non_output=True,
+        allow=[
+            AlchemyResults.SMILES.value,
+            AlchemyResults.INCHI_KEY.value,
+            AlchemyResults.LIGAND_ID.value
+        ],
+    )
+
+    postera_uploader = PosteraUploader(
+        settings=PosteraSettings(),
+        molecule_set_name=molecule_set_name,
+        id_field=AlchemyResults.LIGAND_ID.value,
+        smiles_field=AlchemyResults.SMILES.value
+    )
+
+    _, _, made_new_molset = postera_uploader.push(result_df)
+
+    return made_new_molset

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -30,7 +30,7 @@ def pull_from_postera(molecule_set_name: str):
 
 def upload_to_postera(
     molecule_set_name: str, target: str, absolute_dg_predictions: pd.DataFrame
-) -> bool:
+):
     """
     A convenience method to format predicted absolute DG values using Alchemy and upload to postera with tucked imports
     to avoid importing Postera tools.
@@ -39,9 +39,6 @@ def upload_to_postera(
         molecule_set_name: The name of the molecule set in postera the results should be attached to.
         target: The name of the biological target this result is associated with.
         absolute_dg_predictions: The dataset of absolute dg predictions created by asap-alchemy.
-
-    Returns:
-        `True` if a new molecule set was made else `False` if we just update an existing set.
     """
     from enum import Enum
 
@@ -52,7 +49,7 @@ def upload_to_postera(
     from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
     from asapdiscovery.data.services.services_config import PosteraSettings
 
-    # mock some enum to specifiy which columns are allowed?
+    # mock an enum to specify which columns are allowed
     class AlchemyResults(str, Enum):
         SMILES = "SMILES"
         INCHI_KEY = "Inchi_Key"
@@ -84,6 +81,4 @@ def upload_to_postera(
         smiles_field=AlchemyResults.SMILES.value,
     )
 
-    _, _, made_new_molset = postera_uploader.push(result_df)
-
-    return made_new_molset
+    _, _, _ = postera_uploader.push(result_df)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -55,9 +55,7 @@ def upload_to_postera(
         INCHI_KEY = "Inchi_Key"
         LIGAND_ID = "Ligand_ID"
         COMPUTED_BIOCHEMICAL_ACTIVITY_FEC = "computed-FEC-pIC50"
-        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = (
-            "computed-FEC-uncertainty-pIC50"
-        )
+        COMPUTED_BIOCHEMICAL_ACTIVITY_FEC_UNCERTAINTY = "computed-FEC-uncertainty-pIC50"
 
     # convert the dg values to pIC50 with the expected names
     postera_df = dg_to_postera_dataframe(absolute_predictions=absolute_dg_predictions)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -194,9 +194,7 @@ def dg_to_postera_dataframe(absolute_predictions: pd.DataFrame) -> pd.DataFrame:
         postera_df[column] = dG_to_pIC50(postera_df[column].values)
 
         # rename the column
-        postera_df.rename(
-            columns={column: f"computed-{new_name}-pIC50"}, inplace=True
-        )
+        postera_df.rename(columns={column: f"computed-{new_name}-pIC50"}, inplace=True)
     # rename the label column to be clear in postera
     postera_df.rename(columns={"label": "Ligand_ID"}, inplace=True)
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -195,7 +195,7 @@ def dg_to_postera_dataframe(absolute_predictions: pd.DataFrame) -> pd.DataFrame:
 
         # rename the column
         postera_df.rename(
-            columns={column: f"computed-biochemical-activity-{new_name}"}, inplace=True
+            columns={column: f"computed-{new_name}-pIC50"}, inplace=True
         )
     # rename the label column to be clear in postera
     postera_df.rename(columns={"label": "Ligand_ID"}, inplace=True)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/predict.py
@@ -186,7 +186,10 @@ def dg_to_postera_dataframe(absolute_predictions: pd.DataFrame) -> pd.DataFrame:
     # data.services.postera.manifold_data_tags.yaml
     postera_df = absolute_predictions.copy(deep=True)
 
-    for column, new_name in [("DG (kcal/mol) (FECS)", "FEC"), ("uncertainty (kcal/mol) (FECS)", "FEC-uncertainty")]:
+    for column, new_name in [
+        ("DG (kcal/mol) (FECS)", "FEC"),
+        ("uncertainty (kcal/mol) (FECS)", "FEC-uncertainty"),
+    ]:
         # replace the kcal/mol values with pIC50s.
         postera_df[column] = dG_to_pIC50(postera_df[column].values)
 
@@ -195,9 +198,7 @@ def dg_to_postera_dataframe(absolute_predictions: pd.DataFrame) -> pd.DataFrame:
             columns={column: f"computed-biochemical-activity-{new_name}"}, inplace=True
         )
     # rename the label column to be clear in postera
-    postera_df.rename(
-        columns={"label": "Ligand_ID"}, inplace=True
-    )
+    postera_df.rename(columns={"label": "Ligand_ID"}, inplace=True)
 
     return postera_df
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -308,7 +308,7 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
     )
     target: Optional[str] = Field(
         None,
-        description="The name of the biological target associated with this Alchemy network."
+        description="The name of the biological target associated with this Alchemy network.",
     )
 
     class Config:
@@ -380,7 +380,7 @@ class FreeEnergyCalculationFactory(_FreeEnergyBase):
         ligands: list["Ligand"],
         central_ligand: Optional["Ligand"] = None,
         experimental_protocol: Optional[str] = None,
-        target: Optional[str] = None
+        target: Optional[str] = None,
     ) -> FreeEnergyCalculationNetwork:
         """
          Use the factory settings to create a FEC dataset using OpenFE models.

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/schema/fec.py
@@ -306,6 +306,10 @@ class FreeEnergyCalculationNetwork(_FreeEnergyBase):
         None,
         description="The name of the experimental protocol in the CDD vault that should be associated with this Alchemy network.",
     )
+    target: Optional[str] = Field(
+        None,
+        description="The name of the biological target associated with this Alchemy network."
+    )
 
     class Config:
         """Overwrite the class config to freeze the results model"""
@@ -376,6 +380,7 @@ class FreeEnergyCalculationFactory(_FreeEnergyBase):
         ligands: list["Ligand"],
         central_ligand: Optional["Ligand"] = None,
         experimental_protocol: Optional[str] = None,
+        target: Optional[str] = None
     ) -> FreeEnergyCalculationNetwork:
         """
          Use the factory settings to create a FEC dataset using OpenFE models.
@@ -389,6 +394,7 @@ class FreeEnergyCalculationFactory(_FreeEnergyBase):
                 Note this ligand will be deduplicated from the list if it appears in both.
             experimental_protocol: The name of the experimental protocol in the CDD vault that should be
                 associated with this Alchemy network.
+            target: The name of the biological target associated with this Alchemy network.
 
          Returns:
              The planned FEC network which can be executed locally or submitted to alchemiscale.
@@ -420,6 +426,7 @@ class FreeEnergyCalculationFactory(_FreeEnergyBase):
             network=planned_network,
             receptor=receptor.to_json(),
             experimental_protocol=experimental_protocol,
+            target=target,
             **self.dict(exclude={"type", "network_planner"}),
         )
         return planned_fec_network

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -413,6 +413,8 @@ def test_submit_bad_campaign(tyk2_fec_network, tmpdir):
 def test_alchemy_predict_no_experimental_data(tyk2_result_network, tmpdir):
     """Test predicting the absolute and relative free energies with no experimental data, interactive reports should
     not be generated in this mode.
+    We also test that a warning is printed in the terminal as the target is missing so the results can not be uploaded
+    to postera.
     """
 
     runner = CliRunner()
@@ -425,12 +427,15 @@ def test_alchemy_predict_no_experimental_data(tyk2_result_network, tmpdir):
             alchemy,
             [
                 "predict",
+                "-pm",
+                "my-molset"
             ],
         )
         assert result.exit_code == 0
         assert "Loaded FreeEnergyCalculationNetwork from" in result.stdout
         assert "Absolute predictions written" in result.stdout
         assert "Relative predictions written" in result.stdout
+        assert "WARNING a postera molecule set name was provided without a target, results " in result.stdout
         # load the datasets and check the results match what's expected
         absolute_dataframe = pd.read_csv("predictions-absolute-tyk2-small-test.csv")
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_cli.py
@@ -425,17 +425,16 @@ def test_alchemy_predict_no_experimental_data(tyk2_result_network, tmpdir):
 
         result = runner.invoke(
             alchemy,
-            [
-                "predict",
-                "-pm",
-                "my-molset"
-            ],
+            ["predict", "-pm", "my-molset"],
         )
         assert result.exit_code == 0
         assert "Loaded FreeEnergyCalculationNetwork from" in result.stdout
         assert "Absolute predictions written" in result.stdout
         assert "Relative predictions written" in result.stdout
-        assert "WARNING a postera molecule set name was provided without a target, results " in result.stdout
+        assert (
+            "WARNING a postera molecule set name was provided without a target, results "
+            in result.stdout
+        )
         # load the datasets and check the results match what's expected
         absolute_dataframe = pd.read_csv("predictions-absolute-tyk2-small-test.csv")
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -4,11 +4,11 @@ from uuid import uuid4
 import pandas as pd
 import pytest
 from alchemiscale import Scope, ScopedKey
+from asapdiscovery.alchemy.cli.utils import upload_to_postera
 from asapdiscovery.alchemy.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
-from asapdiscovery.alchemy.cli.utils import upload_to_postera
 from gufe.protocols import ProtocolDAGResult, ProtocolUnitResult
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
@@ -323,8 +323,8 @@ def test_get_actioned_weights(alchemiscale_helper, monkeypatch, tyk2_fec_network
 
 def test_upload_to_postera(monkeypatch, tyk2_result_network):
     """A mocked test to make sure the dataframe is formatted correctly ready for upload to postera."""
-    from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
     from asapdiscovery.alchemy.predict import get_data_from_femap
+    from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
 
     fe_map = tyk2_result_network.results.to_fe_map()
     fe_map.generate_absolute_values()
@@ -340,8 +340,13 @@ def test_upload_to_postera(monkeypatch, tyk2_result_network):
     def push(*args, **kwargs):
         df = kwargs["df"]
         # check we have the expected column names
-        assert "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-pIC50_msk" in df.columns
-        assert "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-uncertainty-pIC50_msk" in df.columns
+        assert (
+            "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-pIC50_msk" in df.columns
+        )
+        assert (
+            "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-uncertainty-pIC50_msk"
+            in df.columns
+        )
         assert "Ligand_ID" in df.columns
         assert "SMILES" in df.columns
         assert "Inchi_Key" in df.columns
@@ -353,5 +358,5 @@ def test_upload_to_postera(monkeypatch, tyk2_result_network):
     upload_to_postera(
         molecule_set_name="my_mol_set",
         target="SARS-CoV-2-Mpro",
-        absolute_dg_predictions=absolute_df
+        absolute_dg_predictions=absolute_df,
     )

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -349,7 +349,6 @@ def test_upload_to_postera(monkeypatch, tyk2_result_network):
         )
         assert "Ligand_ID" in df.columns
         assert "SMILES" in df.columns
-        assert "Inchi_Key" in df.columns
         return df, 1, False
 
     monkeypatch.setenv("POSTERA_API_KEY", "my-key")

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -1,7 +1,6 @@
 import itertools
 from uuid import uuid4
 
-import pandas as pd
 import pytest
 from alchemiscale import Scope, ScopedKey
 from asapdiscovery.alchemy.cli.utils import upload_to_postera

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -1,12 +1,14 @@
 import itertools
 from uuid import uuid4
 
+import pandas as pd
 import pytest
 from alchemiscale import Scope, ScopedKey
 from asapdiscovery.alchemy.schema.fec import (
     AlchemiscaleResults,
     FreeEnergyCalculationNetwork,
 )
+from asapdiscovery.alchemy.cli.utils import upload_to_postera
 from gufe.protocols import ProtocolDAGResult, ProtocolUnitResult
 from openfe.protocols.openmm_rfe import RelativeHybridTopologyProtocolResult
 from openff.units import unit as OFFUnit
@@ -317,3 +319,39 @@ def test_get_actioned_weights(alchemiscale_helper, monkeypatch, tyk2_fec_network
     active_network_weights = client.get_actioned_weights()
     # we should have 4 weights from early stopping
     assert active_network_weights == [0.5 for _ in range(4)]
+
+
+def test_upload_to_postera(monkeypatch, tyk2_result_network):
+    """A mocked test to make sure the dataframe is formatted correctly ready for upload to postera."""
+    from asapdiscovery.data.services.postera.postera_uploader import PosteraUploader
+    from asapdiscovery.alchemy.predict import get_data_from_femap
+
+    fe_map = tyk2_result_network.results.to_fe_map()
+    fe_map.generate_absolute_values()
+
+    absolute_df, _ = get_data_from_femap(
+        fe_map=fe_map,
+        ligands=tyk2_result_network.network.ligands,
+        assay_units=None,
+        reference_dataset=None,
+        cdd_protocol=None,
+    )
+
+    def push(*args, **kwargs):
+        df = kwargs["df"]
+        # check we have the expected column names
+        assert "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-pIC50_msk" in df.columns
+        assert "biochemical-activity_SARS-CoV-2-Mpro_computed-FEC-uncertainty-pIC50_msk" in df.columns
+        assert "Ligand_ID" in df.columns
+        assert "SMILES" in df.columns
+        assert "Inchi_Key" in df.columns
+        return df, 1, False
+
+    monkeypatch.setenv("POSTERA_API_KEY", "my-key")
+    monkeypatch.setattr(PosteraUploader, "push", push)
+
+    upload_to_postera(
+        molecule_set_name="my_mol_set",
+        target="SARS-CoV-2-Mpro",
+        absolute_dg_predictions=absolute_df
+    )


### PR DESCRIPTION
## Description
This PR extends the `asap-alchemy predict` CLI to optionally upload predictions to postera manifold. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] add uploading to predict
- [x] track the biological target name on alchemy schema
- [x] add tests to ensure column names are correct 

## Questions
- [ ] should we also be tracking the postera mol set name all the way from prep?

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
