### PR TITLE
ASAP-Alchemy: Prep updates

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -73,7 +73,7 @@ def create(filename: str):
     show_default=True,
 )
 def plan(
-    name: str,
+    name: Optional[str] = None,
     receptor: Optional[str] = None,
     ligands: Optional[str] = None,
     center_ligand: Optional[str] = None,
@@ -113,6 +113,9 @@ def plan(
         click.echo(f"Loading Ligands and protein from AlchemyDataSet {alchemy_dataset}")
         alchemy_ds = AlchemyDataSet.from_file(alchemy_dataset)
         input_ligands = alchemy_ds.posed_ligands
+
+        # workout which name should be used, the CLI input takes priority over the prep `dataset_name`.
+        name = name or alchemy_ds.dataset_name
 
         # write to a temp pdb file and read back in
         with tempfile.NamedTemporaryFile(suffix=".pdb") as fp:

--- a/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
@@ -697,7 +697,8 @@ class RDKitConstrainedPoseGenerator(_BasicConstrainedPoseGenerator):
 
         from openff.toolkit import Molecule
 
-        core_ligand = prepared_complex.ligand.to_rdkit()
+        # make sure we are not using hs placed by prep as a reference coordinate for the generated conformers
+        core_ligand = Chem.RemoveHs(prepared_complex.ligand.to_rdkit())
 
         # setup the rdkit pickle properties to save all molecule properties
         Chem.SetDefaultPickleProperties(Chem.PropertyPickleOptions.AllProps)


### PR DESCRIPTION
## Description
Minor changes to the rdkit pose generation to improve reliability, we now remove the hydrogens from the reference compound when generating the alchemy poses. We can also now use the `dataset_name` from prep during the planning stage.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] allow dataset name to be picked up from prep
- [x] remove hydrogens from reference pose when using rdkit pose generator


## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
