### PR TITLE
drop in `pull_all()` after fixing imports

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 
 from asapdiscovery.data.schema.ligand import Ligand, LigandIdentifiers
 from asapdiscovery.data.services.postera.molecule_set import MoleculeSetAPI
@@ -75,7 +75,7 @@ class PosteraFactory(BaseModel):
             ms_api, self.molecule_set_id, self.molecule_set_name
         )
 
-    def pull_all(self) -> list[Ligand]:
+    def pull_all(self) -> list[Dict]:
         """
         Pull all molecules from all Postera molecule sets
 

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -15,21 +15,15 @@ class PosteraFactory(BaseModel):
         None, description="ID of the molecule set to pull from Postera"
     )
 
-    @root_validator
-    @classmethod
-    def check_molecule_set_name_or_id(cls, values):
-        molecule_set_name = values.get("molecule_set_name")
-        molecule_set_id = values.get("molecule_set_id")
-        if molecule_set_name is None and molecule_set_id is None:
-            raise ValueError("Either molecule_set_name or molecule_set_id must be set")
-        return values
-
     @staticmethod
     def _pull_molecule_set(
         ms_api: MoleculeSetAPI,
         molecule_set_id: Optional[str] = None,
         molecule_set_name: Optional[str] = None,
     ) -> list[Ligand]:
+
+        if molecule_set_id is None and molecule_set_name is None:
+            raise ValueError("You must provide either a molecule set name or ID")
 
         mols, _ = ms_api.get_molecules_from_id_or_name(
             name=molecule_set_name, id=molecule_set_id

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -21,7 +21,6 @@ class PosteraFactory(BaseModel):
         molecule_set_id: Optional[str] = None,
         molecule_set_name: Optional[str] = None,
     ) -> list[Ligand]:
-
         if molecule_set_id is None and molecule_set_name is None:
             raise ValueError("You must provide either a molecule set name or ID")
 

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -1,28 +1,14 @@
-from typing import Optional
-
-from asapdiscovery.data.schema.ligand import Ligand, LigandIdentifiers
 from asapdiscovery.data.services.postera.molecule_set import MoleculeSetAPI
+from asapdiscovery.data.schema.ligand import Ligand, LigandIdentifiers
 from asapdiscovery.data.services.services_config import PosteraSettings
-from pydantic import BaseModel, Field, root_validator
-
+from pydantic import BaseModel, Field
+from typing import Optional
 
 class PosteraFactory(BaseModel):
     settings: PosteraSettings = Field(default_factory=PosteraSettings)
     molecule_set_name: Optional[str] = Field(
-        None, description="Name of the molecule set to pull from Postera"
+        "", description="Name of the molecule set to pull from Postera"
     )
-    molecule_set_id: Optional[str] = Field(
-        None, description="ID of the molecule set to pull from Postera"
-    )
-
-    @root_validator
-    @classmethod
-    def check_molecule_set_name_or_id(cls, values):
-        molecule_set_name = values.get("molecule_set_name")
-        molecule_set_id = values.get("molecule_set_id")
-        if molecule_set_name is None and molecule_set_id is None:
-            raise ValueError("Either molecule_set_name or molecule_set_id must be set")
-        return values
 
     def pull(self) -> list[Ligand]:
         """
@@ -34,15 +20,58 @@ class PosteraFactory(BaseModel):
             List of ligands
         """
         ms_api = MoleculeSetAPI.from_settings(self.settings)
-        mols, _ = ms_api.get_molecules_from_id_or_name(
-            name=self.molecule_set_name, id=self.molecule_set_id
-        )
-        ligands = [
-            Ligand.from_smiles(
+        mols, _ = ms_api.get_molecules_from_id_or_name(self.molecule_set_name)
+
+        # check if there are any custom columns in this moleculeset
+        standard_columns = ['smiles', 'id', 'idx', 'label']
+        custom_data_columns = [ col for col in mols.columns if not col in standard_columns ]
+        
+        ligands = []
+        for _, mol in mols.iterrows():
+            # create the ligand with relevant metadata
+            ligand = Ligand.from_smiles(
                 compound_name=mol.id,
                 smiles=mol.smiles,
-                ids=LigandIdentifiers(manifold_api_id=mol.id),
+                ids=LigandIdentifiers(manifold_api_id=mol.id)
             )
-            for _, mol in mols.iterrows()
-        ]
+            
+            # now append custom data to the Ligand's tags, if there is any
+            tags = {}
+            for custom_col in custom_data_columns:
+                if mol[custom_col] is None:
+                    mol[custom_col] = ""
+                tags[custom_col] = mol[custom_col]
+            
+            ligand.tags = tags
+            ligands.append(ligand)
         return ligands
+    
+    def pull_all(self) -> list[Ligand]:
+        """
+        Pull all molecules from all Postera molecule sets
+
+        Returns
+        -------
+        List[Dict]
+            List of dictionaries, where each dict is a moleculeset with metadata and ligand data
+        """
+        from rich.progress import track
+
+        ms_api = MoleculeSetAPI.from_settings(self.settings)
+        available_msets = ms_api.list_available()
+
+        all_mset_data = []
+        for mset_uuid, _ in track(available_msets.items(), total=len(available_msets), 
+                          description=f"Processing {len(available_msets)} available moleculesets.."):
+            # gather metadata of this mset
+            mset_metadata = ms_api.get(mset_uuid) # need to use UUID here instead of name for postera API reasons.
+
+            # gather compound data contained in this mset
+            self.molecule_set_name = mset_uuid
+            mset_compound_data = self.pull()
+
+            # add to metadata, and add the whole thing to the data bucket
+            mset_metadata['ligand_data'] = mset_compound_data
+            all_mset_data.append(mset_metadata)
+
+        return all_mset_data

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -1,8 +1,10 @@
-from asapdiscovery.data.services.postera.molecule_set import MoleculeSetAPI
+from typing import Optional
+
 from asapdiscovery.data.schema.ligand import Ligand, LigandIdentifiers
+from asapdiscovery.data.services.postera.molecule_set import MoleculeSetAPI
 from asapdiscovery.data.services.services_config import PosteraSettings
 from pydantic import BaseModel, Field
-from typing import Optional
+
 
 class PosteraFactory(BaseModel):
     settings: PosteraSettings = Field(default_factory=PosteraSettings)
@@ -23,29 +25,31 @@ class PosteraFactory(BaseModel):
         mols, _ = ms_api.get_molecules_from_id_or_name(self.molecule_set_name)
 
         # check if there are any custom columns in this moleculeset
-        standard_columns = ['smiles', 'id', 'idx', 'label']
-        custom_data_columns = [ col for col in mols.columns if not col in standard_columns ]
-        
+        standard_columns = ["smiles", "id", "idx", "label"]
+        custom_data_columns = [
+            col for col in mols.columns if not col in standard_columns
+        ]
+
         ligands = []
         for _, mol in mols.iterrows():
             # create the ligand with relevant metadata
             ligand = Ligand.from_smiles(
                 compound_name=mol.id,
                 smiles=mol.smiles,
-                ids=LigandIdentifiers(manifold_api_id=mol.id)
+                ids=LigandIdentifiers(manifold_api_id=mol.id),
             )
-            
+
             # now append custom data to the Ligand's tags, if there is any
             tags = {}
             for custom_col in custom_data_columns:
                 if mol[custom_col] is None:
                     mol[custom_col] = ""
                 tags[custom_col] = mol[custom_col]
-            
+
             ligand.tags = tags
             ligands.append(ligand)
         return ligands
-    
+
     def pull_all(self) -> list[Ligand]:
         """
         Pull all molecules from all Postera molecule sets
@@ -61,17 +65,22 @@ class PosteraFactory(BaseModel):
         available_msets = ms_api.list_available()
 
         all_mset_data = []
-        for mset_uuid, _ in track(available_msets.items(), total=len(available_msets), 
-                          description=f"Processing {len(available_msets)} available moleculesets.."):
+        for mset_uuid, _ in track(
+            available_msets.items(),
+            total=len(available_msets),
+            description=f"Processing {len(available_msets)} available moleculesets..",
+        ):
             # gather metadata of this mset
-            mset_metadata = ms_api.get(mset_uuid) # need to use UUID here instead of name for postera API reasons.
+            mset_metadata = ms_api.get(
+                mset_uuid
+            )  # need to use UUID here instead of name for postera API reasons.
 
             # gather compound data contained in this mset
             self.molecule_set_name = mset_uuid
             mset_compound_data = self.pull()
 
             # add to metadata, and add the whole thing to the data bucket
-            mset_metadata['ligand_data'] = mset_compound_data
+            mset_metadata["ligand_data"] = mset_compound_data
             all_mset_data.append(mset_metadata)
 
         return all_mset_data

--- a/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/postera/postera_factory.py
@@ -1,9 +1,9 @@
-from typing import Dict, Optional
+from typing import Optional
 
 from asapdiscovery.data.schema.ligand import Ligand, LigandIdentifiers
 from asapdiscovery.data.services.postera.molecule_set import MoleculeSetAPI
 from asapdiscovery.data.services.services_config import PosteraSettings
-from pydantic import BaseModel, Field, root_validator
+from pydantic import BaseModel, Field
 
 
 class PosteraFactory(BaseModel):
@@ -31,7 +31,7 @@ class PosteraFactory(BaseModel):
         # check if there are any custom columns in this moleculeset
         standard_columns = ["smiles", "id", "idx", "label"]
         custom_data_columns = [
-            col for col in mols.columns if not col in standard_columns
+            col for col in mols.columns if col not in standard_columns
         ]
 
         ligands = []

--- a/asapdiscovery-data/asapdiscovery/data/tests/postera/test_postera_live.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/postera/test_postera_live.py
@@ -555,7 +555,7 @@ class TestPosteraLive:
         assert "CCCC" in ret_data["smiles"].tolist()
         assert "CCCCCCCC" in ret_data["smiles"].tolist()
 
-    def test_factory_name(
+    def test_factory_pull_all(
         self, simple_moleculeset, postera_settings, live_postera_ms_api_instance
     ):
         molecule_set_name, uuid = simple_moleculeset

--- a/asapdiscovery-data/asapdiscovery/data/tests/postera/test_postera_live.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/postera/test_postera_live.py
@@ -554,3 +554,13 @@ class TestPosteraLive:
         assert "CCCCCF" in ret_data["smiles"].tolist()
         assert "CCCC" in ret_data["smiles"].tolist()
         assert "CCCCCCCC" in ret_data["smiles"].tolist()
+
+    def test_factory_name(
+        self, simple_moleculeset, postera_settings, live_postera_ms_api_instance
+    ):
+        molecule_set_name, uuid = simple_moleculeset
+        factory = PosteraFactory(settings=postera_settings)
+        mset_data = factory.pull_all()
+        assert len(mset_data) > 0
+        assert isinstance(mset_data[0], dict)
+        assert mset_data[0]["ligand_data"] is not None


### PR DESCRIPTION
enables pulling _all_ MoleculeSets at the same time without having to specify MoleculeSet names. @hmacdope any tests needed here?

## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
