### PR TITLE
Set order asap cli

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -5,15 +5,15 @@ from asapdiscovery.data.services.postera.manifold_data_validation import (
     TagEnumBase,
     TargetTags,
 )
+from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
 
-
-@click.group()
+@click.group(cls=SpecialHelpOrder)
 def alchemy():
     """Tools to create and execute Alchemy networks using OpenFE and alchemiscale."""
     pass
 
 
-@alchemy.command()
+@alchemy.command(help_priority=1, short_help="Create a new free energy perturbation factory with default settings and save it to JSON file.")
 @click.argument(
     "filename",
     type=click.Path(exists=False, file_okay=True, dir_okay=False, writable=True),
@@ -31,7 +31,7 @@ def create(filename: str):
     factory.to_file(filename=filename)
 
 
-@alchemy.command()
+@alchemy.command(help_priority=2, short_help="Plan a FreeEnergyCalculationNetwork using the given factory and inputs. The planned network will be written to file in a folder named after the dataset.")
 @click.option(
     "-f",
     "--factory-file",
@@ -174,7 +174,7 @@ def plan(
         output.write(planned_network.network.graphml)
 
 
-@alchemy.command()
+@alchemy.command(help_priority=3, short_help="Submit a local FreeEnergyCalculationNetwork to alchemiscale using the provided scope details. The network object will have these details saved into it.")
 @click.option(
     "-n",
     "--network",
@@ -266,7 +266,7 @@ def submit(
     )
 
 
-@alchemy.command()
+@alchemy.command(help_priority=7, short_help="Gather the results from alchemiscale for the given network.")
 @click.option(
     "-n",
     "--network",
@@ -319,7 +319,7 @@ def gather(network: str, allow_missing: bool):
     network_with_results.to_file("result_network.json")
 
 
-@alchemy.command()
+@alchemy.command(help_priority=4, short_help="Get the status of the submitted network on alchemiscale.")
 @click.option(
     "-n",
     "--network",
@@ -455,7 +455,7 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
                 click.echo()
 
 
-@alchemy.command()
+@alchemy.command(help_priority=5, short_help="Restart errored Tasks for the given FEC network.")
 @click.option(
     "-n",
     "--network",
@@ -496,7 +496,7 @@ def restart(network: str, verbose: bool, tasks):
         click.echo(f"Restarted {len(restarted_tasks)} Tasks")
 
 
-@alchemy.command()
+@alchemy.command(help_priority=6, short_help="Stop (i.e. set to 'error') a network's running and waiting tasks.")
 @click.option(
     "-nk",
     "--network-key",
@@ -531,7 +531,7 @@ def stop(network_key: str):
     console.print(message)
 
 
-@alchemy.command()
+@alchemy.command(help_priority=7, short_help="Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the results to the relevant energy range.")
 @click.option(
     "-n",
     "--network",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -6,8 +6,9 @@ from asapdiscovery.data.services.postera.manifold_data_validation import (
     TargetTags,
 )
 from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
+import shutil
 
-@click.group(cls=SpecialHelpOrder)
+@click.group(cls=SpecialHelpOrder, context_settings={'max_content_width': shutil.get_terminal_size().columns - 20})
 def alchemy():
     """Tools to create and execute Alchemy networks using OpenFE and alchemiscale."""
     pass

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/alchemy.py
@@ -1,20 +1,27 @@
+import shutil
 from typing import Optional
 
 import click
+from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
 from asapdiscovery.data.services.postera.manifold_data_validation import (
     TagEnumBase,
     TargetTags,
 )
-from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
-import shutil
 
-@click.group(cls=SpecialHelpOrder, context_settings={'max_content_width': shutil.get_terminal_size().columns - 20})
+
+@click.group(
+    cls=SpecialHelpOrder,
+    context_settings={"max_content_width": shutil.get_terminal_size().columns - 20},
+)
 def alchemy():
     """Tools to create and execute Alchemy networks using OpenFE and alchemiscale."""
     pass
 
 
-@alchemy.command(help_priority=1, short_help="Create a new free energy perturbation factory with default settings and save it to JSON file.")
+@alchemy.command(
+    help_priority=1,
+    short_help="Create a new free energy perturbation factory with default settings and save it to JSON file.",
+)
 @click.argument(
     "filename",
     type=click.Path(exists=False, file_okay=True, dir_okay=False, writable=True),
@@ -32,7 +39,10 @@ def create(filename: str):
     factory.to_file(filename=filename)
 
 
-@alchemy.command(help_priority=2, short_help="Plan a FreeEnergyCalculationNetwork using the given factory and inputs. The planned network will be written to file in a folder named after the dataset.")
+@alchemy.command(
+    help_priority=2,
+    short_help="Plan a FreeEnergyCalculationNetwork using the given factory and inputs. The planned network will be written to file in a folder named after the dataset.",
+)
 @click.option(
     "-f",
     "--factory-file",
@@ -175,7 +185,10 @@ def plan(
         output.write(planned_network.network.graphml)
 
 
-@alchemy.command(help_priority=3, short_help="Submit a local FreeEnergyCalculationNetwork to alchemiscale using the provided scope details. The network object will have these details saved into it.")
+@alchemy.command(
+    help_priority=3,
+    short_help="Submit a local FreeEnergyCalculationNetwork to alchemiscale using the provided scope details. The network object will have these details saved into it.",
+)
 @click.option(
     "-n",
     "--network",
@@ -267,7 +280,10 @@ def submit(
     )
 
 
-@alchemy.command(help_priority=7, short_help="Gather the results from alchemiscale for the given network.")
+@alchemy.command(
+    help_priority=7,
+    short_help="Gather the results from alchemiscale for the given network.",
+)
 @click.option(
     "-n",
     "--network",
@@ -320,7 +336,10 @@ def gather(network: str, allow_missing: bool):
     network_with_results.to_file("result_network.json")
 
 
-@alchemy.command(help_priority=4, short_help="Get the status of the submitted network on alchemiscale.")
+@alchemy.command(
+    help_priority=4,
+    short_help="Get the status of the submitted network on alchemiscale.",
+)
 @click.option(
     "-n",
     "--network",
@@ -456,7 +475,9 @@ def status(network: str, errors: bool, with_traceback: bool, all_networks: bool)
                 click.echo()
 
 
-@alchemy.command(help_priority=5, short_help="Restart errored Tasks for the given FEC network.")
+@alchemy.command(
+    help_priority=5, short_help="Restart errored Tasks for the given FEC network."
+)
 @click.option(
     "-n",
     "--network",
@@ -497,7 +518,10 @@ def restart(network: str, verbose: bool, tasks):
         click.echo(f"Restarted {len(restarted_tasks)} Tasks")
 
 
-@alchemy.command(help_priority=6, short_help="Stop (i.e. set to 'error') a network's running and waiting tasks.")
+@alchemy.command(
+    help_priority=6,
+    short_help="Stop (i.e. set to 'error') a network's running and waiting tasks.",
+)
 @click.option(
     "-nk",
     "--network-key",
@@ -532,7 +556,10 @@ def stop(network_key: str):
     console.print(message)
 
 
-@alchemy.command(help_priority=7, short_help="Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the results to the relevant energy range.")
+@alchemy.command(
+    help_priority=7,
+    short_help="Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the results to the relevant energy range.",
+)
 @click.option(
     "-n",
     "--network",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -3,12 +3,12 @@ from typing import Optional
 import click
 
 
-@click.group()
+@click.group(short_help="Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.")
 def prep():
     """Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation."""
 
 
-@prep.command()
+@prep.command(short_help="Create a new AlchemyPrepWorkflow with default settings and save it to JSON file.")
 @click.option(
     "-f",
     "--filename",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -2,8 +2,11 @@ from typing import Optional
 
 import click
 
+from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
+import shutil
 
-@click.group(short_help="Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.")
+@click.group(short_help="Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.",
+             cls=SpecialHelpOrder, context_settings={'max_content_width': shutil.get_terminal_size().columns - 20})
 def prep():
     """Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation."""
 
@@ -44,7 +47,7 @@ def create(filename: str, core_smarts: str):
     console.print(message)
 
 
-@prep.command()
+@prep.command(short_help="Create an AlchemyDataset by running the given AlchemyPrepWorkflow which will expand the ligand states and generate constrained poses suitable for ASAP-Alchemy.")
 @click.option(
     "-f",
     "--factory-file",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -1,17 +1,22 @@
+import shutil
 from typing import Optional
 
 import click
-
 from asapdiscovery.alchemy.cli.utils import SpecialHelpOrder
-import shutil
 
-@click.group(short_help="Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.",
-             cls=SpecialHelpOrder, context_settings={'max_content_width': shutil.get_terminal_size().columns - 20})
+
+@click.group(
+    short_help="Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.",
+    cls=SpecialHelpOrder,
+    context_settings={"max_content_width": shutil.get_terminal_size().columns - 20},
+)
 def prep():
     """Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation."""
 
 
-@prep.command(short_help="Create a new AlchemyPrepWorkflow with default settings and save it to JSON file.")
+@prep.command(
+    short_help="Create a new AlchemyPrepWorkflow with default settings and save it to JSON file."
+)
 @click.option(
     "-f",
     "--filename",
@@ -47,7 +52,9 @@ def create(filename: str, core_smarts: str):
     console.print(message)
 
 
-@prep.command(short_help="Create an AlchemyDataset by running the given AlchemyPrepWorkflow which will expand the ligand states and generate constrained poses suitable for ASAP-Alchemy.")
+@prep.command(
+    short_help="Create an AlchemyDataset by running the given AlchemyPrepWorkflow which will expand the ligand states and generate constrained poses suitable for ASAP-Alchemy."
+)
 @click.option(
     "-f",
     "--factory-file",

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import rich
-
+import click
 
 def print_header(console: "rich.Console"):
     """Print an ASAP-Alchemy header"""
@@ -78,3 +78,34 @@ def upload_to_postera(
     )
 
     _, _, _ = postera_uploader.push(df=result_df)
+
+class SpecialHelpOrder(click.Group):
+    # from https://stackoverflow.com/questions/47972638/how-can-i-define-the-order-of-click-sub-commands-in-help
+    def __init__(self, *args, **kwargs):
+        self.help_priorities = {}
+        super(SpecialHelpOrder, self).__init__(*args, **kwargs)
+
+    def get_help(self, ctx):
+        self.list_commands = self.list_commands_for_help
+        return super(SpecialHelpOrder, self).get_help(ctx)
+
+    def list_commands_for_help(self, ctx):
+        """reorder the list of commands when listing the help"""
+        commands = super(SpecialHelpOrder, self).list_commands(ctx)
+        return (c[1] for c in sorted(
+            (self.help_priorities.get(command, 1), command)
+            for command in commands))
+
+    def command(self, *args, **kwargs):
+        """Behaves the same as `click.Group.command()` except capture
+        a priority for listing command names in help.
+        """
+        help_priority = kwargs.pop('help_priority', 1)
+        help_priorities = self.help_priorities
+
+        def decorator(f):
+            cmd = super(SpecialHelpOrder, self).command(*args, **kwargs)(f)
+            help_priorities[cmd.name] = help_priority
+            return cmd
+
+        return decorator

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -1,6 +1,7 @@
+import click
 import pandas as pd
 import rich
-import click
+
 
 def print_header(console: "rich.Console"):
     """Print an ASAP-Alchemy header"""
@@ -79,28 +80,32 @@ def upload_to_postera(
 
     _, _, _ = postera_uploader.push(df=result_df)
 
+
 class SpecialHelpOrder(click.Group):
     # from https://stackoverflow.com/questions/47972638/how-can-i-define-the-order-of-click-sub-commands-in-help
     def __init__(self, *args, **kwargs):
         self.help_priorities = {}
-        super(SpecialHelpOrder, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def get_help(self, ctx):
         self.list_commands = self.list_commands_for_help
-        return super(SpecialHelpOrder, self).get_help(ctx)
+        return super().get_help(ctx)
 
     def list_commands_for_help(self, ctx):
         """reorder the list of commands when listing the help"""
-        commands = super(SpecialHelpOrder, self).list_commands(ctx)
-        return (c[1] for c in sorted(
-            (self.help_priorities.get(command, 1), command)
-            for command in commands))
+        commands = super().list_commands(ctx)
+        return (
+            c[1]
+            for c in sorted(
+                (self.help_priorities.get(command, 1), command) for command in commands
+            )
+        )
 
     def command(self, *args, **kwargs):
         """Behaves the same as `click.Group.command()` except capture
         a priority for listing command names in help.
         """
-        help_priority = kwargs.pop('help_priority', 1)
+        help_priority = kwargs.pop("help_priority", 1)
         help_priorities = self.help_priorities
 
         def decorator(f):


### PR DESCRIPTION
Solves https://github.com/choderalab/asapdiscovery/issues/896, makes sure that info messages aren't truncated and that we use more columns in the terminal to get less wrapping.

Makes CLI help printout look like:
```
$ asap-alchemy --help
Usage: asap-alchemy [OPTIONS] COMMAND [ARGS]...

  Tools to create and execute Alchemy networks using OpenFE and alchemiscale.

Options:
  --help  Show this message and exit.

Commands:
  create   Create a new free energy perturbation factory with default settings and save it to JSON file.
  prep     Tools to prepare ligands for Alchemy networks via state expansion and constrained pose generation.
  plan     Plan a FreeEnergyCalculationNetwork using the given factory and inputs. The planned network will be written to file in a folder named after the
           dataset.
  submit   Submit a local FreeEnergyCalculationNetwork to alchemiscale using the provided scope details. The network object will have these details saved
           into it.
  status   Get the status of the submitted network on alchemiscale.
  restart  Restart errored Tasks for the given FEC network.
  stop     Stop (i.e. set to 'error') a network's running and waiting tasks.
  gather   Gather the results from alchemiscale for the given network.
  predict  Predict relative and absolute free energies for the set of ligands, using any provided experimental data to shift the results to the relevant
           energy range.
```



## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
