### PR TITLE
Fix  .readthedocs.yaml to install other packages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,14 +19,20 @@ python:
     - method: pip
       path: asapdiscovery-alchemy
     - method: pip
+      path: asapdiscovery-cli
+    - method: pip
       path: asapdiscovery-data
     - method: pip
       path: asapdiscovery-dataviz
     - method: pip
       path: asapdiscovery-docking
     - method: pip
+      path: asapdiscovery-genetics
+    - method: pip
       path: asapdiscovery-ml
     - method: pip
       path: asapdiscovery-modeling
     - method: pip
       path: asapdiscovery-simulation
+    - method: pip
+      path: asapdiscovery-workflows


### PR DESCRIPTION
Fixes #992 


## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
