### PR TITLE
`ASAP-Alchemy`: Remove potential covalent ligands from CDD downloads

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -210,8 +210,12 @@ def run(
             f"Downloading experimental ligands from CDD protocol {experimental_protocol}"
         )
         cdd_status.start()
-        # get all molecules with data for the given protocol
-        ref_ligands = get_cdd_molecules(protocol_name=experimental_protocol)
+        # get all molecules with data for the given protocol, removing stereo issues and possible warheads
+        ref_ligands = get_cdd_molecules(
+            protocol_name=experimental_protocol,
+            defined_stereo_only=True,
+            remove_covalent=True
+        )
         cdd_status.stop()
 
         message = Padding(

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/prep.py
@@ -214,7 +214,7 @@ def run(
         ref_ligands = get_cdd_molecules(
             protocol_name=experimental_protocol,
             defined_stereo_only=True,
-            remove_covalent=True
+            remove_covalent=True,
         )
         cdd_status.stop()
 

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -186,7 +186,7 @@ def has_warhead(ligand: "Ligand") -> bool:
         "nitrile": "N#[C:1]-[*]",
         "nitrile_adduct": "C-S-[C:1](=N)",
         "propiolamide": "NC(=O)C#C",
-        "sulfamate": "NS(=O)(=O)O"
+        "sulfamate": "NS(=O)(=O)O",
     }
     rdkit_mol = ligand.to_rdkit()
     for smarts in covalent_warhead_smarts.values():

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -87,7 +87,7 @@ def upload_to_postera(
 
 
 def get_cdd_molecules(
-    protocol_name: str, defined_stereo_only: bool = True
+    protocol_name: str, defined_stereo_only: bool = True, remove_covalent: bool = True
 ) -> list["Ligand"]:
     """
     Search the CDD protocol for molecules with experimental values and return a list of asapdiscovery ligands.
@@ -98,6 +98,8 @@ def get_cdd_molecules(
     Args:
         protocol_name: The name of the experimental protocol in CDD we should extract molecules from.
         defined_stereo_only: Only return ligands which have fully defined stereochemistry
+        remove_covalent: If `True` remove potential covalent ligands from the protocol based on the presence of warheads
+            found via smarts matches.
 
     Returns:
         A list of molecules with experimental data.
@@ -147,7 +149,48 @@ def get_cdd_molecules(
 
         ref_ligands = defined_ligands
 
+    if remove_covalent:
+        # remove any ligands which contain potential covalent warheads
+        non_covalent_ligands = []
+        for mol in ref_ligands:
+            if not has_warhead(ligand=mol):
+                non_covalent_ligands.append(mol)
+
+        ref_ligands = non_covalent_ligands
+
     return ref_ligands
+
+
+def has_warhead(ligand: "Ligand") -> bool:
+    """
+    Check if the molecule has a potential covalent warhead based on the presence of some simple SMARTS patterns.
+
+    Args:
+        ligand: The ligand which we should check for potential covalent warheads
+
+    Returns:
+        `True` if the ligand has a possible warhead else `False`.
+
+    Notes:
+        The list of possible warheads is not exhaustive and so the molecule may still be a covalent ligand.
+    """
+    from rdkit import Chem
+
+    covalent_warhead_smarts = {
+        'acrylamide': '[C;H2:1]=[C;H1]C(N)=O',
+        'acrylamide_adduct': 'NC(C[C:1]S)=O',
+        'chloroacetamide': 'Cl[C;H2:1]C(N)=O',
+        'chloroacetamide_adduct': 'S[C:1]C(N)=O',
+        'vinylsulfonamide': 'NS(=O)([C;H1]=[C;H2:1])=O',
+        'vinylsulfonamide_adduct': 'NS(=O)(C[C:1]S)=O',
+        'nitrile': 'N#[C:1]-[*]',
+        'nitrile_adduct': 'C-S-[C:1](=N)',
+    }
+    rdkit_mol = ligand.to_rdkit()
+    for smarts in covalent_warhead_smarts.values():
+        if rdkit_mol.HasSubstructMatch(Chem.MolFromSmarts(smarts)):
+            return True
+    return False
 
 
 class SpecialHelpOrder(click.Group):

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -185,6 +185,8 @@ def has_warhead(ligand: "Ligand") -> bool:
         "vinylsulfonamide_adduct": "NS(=O)(C[C:1]S)=O",
         "nitrile": "N#[C:1]-[*]",
         "nitrile_adduct": "C-S-[C:1](=N)",
+        "propiolamide": "NC(=O)C#C",
+        "sulfamate": "NS(=O)(=O)O"
     }
     rdkit_mol = ligand.to_rdkit()
     for smarts in covalent_warhead_smarts.values():

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -177,14 +177,14 @@ def has_warhead(ligand: "Ligand") -> bool:
     from rdkit import Chem
 
     covalent_warhead_smarts = {
-        'acrylamide': '[C;H2:1]=[C;H1]C(N)=O',
-        'acrylamide_adduct': 'NC(C[C:1]S)=O',
-        'chloroacetamide': 'Cl[C;H2:1]C(N)=O',
-        'chloroacetamide_adduct': 'S[C:1]C(N)=O',
-        'vinylsulfonamide': 'NS(=O)([C;H1]=[C;H2:1])=O',
-        'vinylsulfonamide_adduct': 'NS(=O)(C[C:1]S)=O',
-        'nitrile': 'N#[C:1]-[*]',
-        'nitrile_adduct': 'C-S-[C:1](=N)',
+        "acrylamide": "[C;H2:1]=[C;H1]C(N)=O",
+        "acrylamide_adduct": "NC(C[C:1]S)=O",
+        "chloroacetamide": "Cl[C;H2:1]C(N)=O",
+        "chloroacetamide_adduct": "S[C:1]C(N)=O",
+        "vinylsulfonamide": "NS(=O)([C;H1]=[C;H2:1])=O",
+        "vinylsulfonamide_adduct": "NS(=O)(C[C:1]S)=O",
+        "nitrile": "N#[C:1]-[*]",
+        "nitrile_adduct": "C-S-[C:1](=N)",
     }
     rdkit_mol = ligand.to_rdkit()
     for smarts in covalent_warhead_smarts.values():

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -367,7 +367,7 @@ def test_upload_to_postera(monkeypatch, tyk2_result_network):
         pytest.param(True, 1, True, id="Defined only no warhead."),
         pytest.param(False, 2, True, id="All ligands no warhead."),
         pytest.param(True, 2, False, id="Defined only with warhead"),
-        pytest.param(False, 3, False, id="All ligands with warhead.")
+        pytest.param(False, 3, False, id="All ligands with warhead."),
     ],
 )
 def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands, remove_covalent):
@@ -384,10 +384,10 @@ def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands, remove_cov
                 "CXSmiles": "NC(C)C(=O)O",
             },
             {
-                "Smiles": "CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N",
+                "Smiles": r"CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N",
                 "Molecule Name": "Neratinib",
-                "CXSmiles": "CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N"
-            }
+                "CXSmiles": r"CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N",
+            },
         ]
         return pandas.DataFrame(data)
 
@@ -396,7 +396,9 @@ def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands, remove_cov
     )
 
     molecules = get_cdd_molecules(
-        protocol_name="my-protocol", defined_stereo_only=defined_only, remove_covalent=remove_covalent
+        protocol_name="my-protocol",
+        defined_stereo_only=defined_only,
+        remove_covalent=remove_covalent,
     )
     assert len(molecules) == n_ligands
     # check they are marked as experimental

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -362,13 +362,15 @@ def test_upload_to_postera(monkeypatch, tyk2_result_network):
 
 
 @pytest.mark.parametrize(
-    "defined_only, n_ligands",
+    "defined_only, n_ligands, remove_covalent",
     [
-        pytest.param(True, 1, id="Defined only."),
-        pytest.param(False, 2, id="All ligands."),
+        pytest.param(True, 1, True, id="Defined only no warhead."),
+        pytest.param(False, 2, True, id="All ligands no warhead."),
+        pytest.param(True, 2, False, id="Defined only with warhead"),
+        pytest.param(False, 3, False, id="All ligands with warhead.")
     ],
 )
-def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands):
+def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands, remove_covalent):
     """Test downloading molecules from a cdd mocked protocol and removing molecules with undefined stereo."""
 
     import asapdiscovery.alchemy.predict
@@ -381,6 +383,11 @@ def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands):
                 "Molecule Name": "alanine",
                 "CXSmiles": "NC(C)C(=O)O",
             },
+            {
+                "Smiles": "CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N",
+                "Molecule Name": "Neratinib",
+                "CXSmiles": "CCOC1=C(NC(=O)\C=C\CN(C)C)C=C2C(NC3=CC=C(OCC4=CC=CC=N4)C(Cl)=C3)=C(C=NC2=C1)C#N"
+            }
         ]
         return pandas.DataFrame(data)
 
@@ -389,7 +396,7 @@ def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands):
     )
 
     molecules = get_cdd_molecules(
-        protocol_name="my-protocol", defined_stereo_only=defined_only
+        protocol_name="my-protocol", defined_stereo_only=defined_only, remove_covalent=remove_covalent
     )
     assert len(molecules) == n_ligands
     # check they are marked as experimental


### PR DESCRIPTION
## Description
This PR extends the CDD downloader utility to flag potential covalent ligands to ensure they are not used as references in the RBFE calculations. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Flag potential warheads and remove from the download

## Questions
- [ ] Are there any other ways we could flag the ligands? 

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
