### PR TITLE
`asap-docking` don't return None in POSITDocker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,9 @@ ENV/
 ._*
 .DS*
 
+# VSCode files
+.vscode/
+
 # Rope project settings
 .ropeproject
 

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -333,7 +333,8 @@ class POSITDocker(DockingBase):
                     error_msg = f"docking failed for input pair with compound name: {set.ligand.compound_name}, smiles: {set.ligand.smiles} and target name: {set.complex.target.target_name}"
                     if error == "skip":
                         logger.warn(error_msg)
-                        docking_results.append(None)
+                        # Need to have a result for dask to be happy
+                        # docking_results.append(None)
                     elif error == "raise":
                         raise ValueError(error_msg)
                     else:


### PR DESCRIPTION
## Description
fixes #989 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] change POSITDocker to not return anything in the case of a skipped failure
- [ ] write a test to catch this bug

## Questions
- [ ] in terms of test writing - it seems overkill to go through docking that we know fails just to test what happens when it fails, but I'm not sure how else to test it?

## Status
- [ ] Ready to go


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
