### PR TITLE
`ASAP-Alchemy`: Catch radicals in CDD downloading

### DIFF
--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -125,7 +125,7 @@ def get_cdd_molecules(
         # remove ligands with undefined or non-absolute stereochemistry
         defined_ligands = []
         from openff.toolkit import Molecule
-        from openff.toolkit.utils.exceptions import UndefinedStereochemistryError
+        from openff.toolkit.utils.exceptions import UndefinedStereochemistryError, RadicalsNotSupportedError
         from rdkit import Chem
 
         for mol in ref_ligands:
@@ -144,7 +144,7 @@ def get_cdd_molecules(
                 # if we make it through all checks add the molecule
                 defined_ligands.append(mol)
 
-            except UndefinedStereochemistryError:
+            except (UndefinedStereochemistryError, RadicalsNotSupportedError):
                 continue
 
         ref_ligands = defined_ligands

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -136,10 +136,7 @@ def get_cdd_molecules(
             rdmol = Chem.MolFromSmiles(mol.tags["cxsmiles"])
             groups = rdmol.GetStereoGroups()
             for stereo_group in groups:
-                if (
-                    stereo_group.GetGroupType()
-                    != Chem.StereoGroupType.STEREO_ABSOLUTE
-                ):
+                if stereo_group.GetGroupType() != Chem.StereoGroupType.STEREO_ABSOLUTE:
                     raise UndefinedStereochemistryError("missing absolute stereo")
             # if we make it through all checks add the molecule
             defined_ligands.append(mol)

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -106,6 +106,12 @@ def get_cdd_molecules(
     """
     from asapdiscovery.alchemy.predict import download_cdd_data
     from asapdiscovery.data.schema.ligand import Ligand
+    from openff.toolkit import Molecule
+    from openff.toolkit.utils.exceptions import (
+        RadicalsNotSupportedError,
+        UndefinedStereochemistryError,
+    )
+    from rdkit import Chem
 
     # get all molecules with data for the protocol
     cdd_data = download_cdd_data(protocol_name=protocol_name)
@@ -121,33 +127,31 @@ def get_cdd_molecules(
         asap_mol.tags["experimental"] = "True"
         ref_ligands.append(asap_mol)
 
-    if defined_stereo_only:
-        # remove ligands with undefined or non-absolute stereochemistry
-        defined_ligands = []
-        from openff.toolkit import Molecule
-        from openff.toolkit.utils.exceptions import (
-            RadicalsNotSupportedError,
-            UndefinedStereochemistryError,
-        )
-        from rdkit import Chem
+    defined_ligands = []
+    for mol in ref_ligands:
+        try:
+            # this checks for any undefined stereo centers
+            _ = Molecule.from_smiles(mol.smiles)
+            # check for non-absolute centers using the enhanced stereo smiles
+            rdmol = Chem.MolFromSmiles(mol.tags["cxsmiles"])
+            groups = rdmol.GetStereoGroups()
+            for stereo_group in groups:
+                if (
+                    stereo_group.GetGroupType()
+                    != Chem.StereoGroupType.STEREO_ABSOLUTE
+                ):
+                    raise UndefinedStereochemistryError("missing absolute stereo")
+            # if we make it through all checks add the molecule
+            defined_ligands.append(mol)
 
-        for mol in ref_ligands:
-            try:
-                # this checks for any undefined stereo centers
-                _ = Molecule.from_smiles(mol.smiles)
-                # check for non-absolute centers using the enhanced stereo smiles
-                rdmol = Chem.MolFromSmiles(mol.tags["cxsmiles"])
-                groups = rdmol.GetStereoGroups()
-                for stereo_group in groups:
-                    if (
-                        stereo_group.GetGroupType()
-                        != Chem.StereoGroupType.STEREO_ABSOLUTE
-                    ):
-                        raise UndefinedStereochemistryError("missing absolute stereo")
-                # if we make it through all checks add the molecule
+        except RadicalsNotSupportedError:
+            # always remove radicals
+            continue
+        except UndefinedStereochemistryError:
+            # only remove undefined stereo when requested
+            if not defined_stereo_only:
                 defined_ligands.append(mol)
-
-            except (UndefinedStereochemistryError, RadicalsNotSupportedError):
+            else:
                 continue
 
         ref_ligands = defined_ligands

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/cli/utils.py
@@ -125,7 +125,10 @@ def get_cdd_molecules(
         # remove ligands with undefined or non-absolute stereochemistry
         defined_ligands = []
         from openff.toolkit import Molecule
-        from openff.toolkit.utils.exceptions import UndefinedStereochemistryError, RadicalsNotSupportedError
+        from openff.toolkit.utils.exceptions import (
+            RadicalsNotSupportedError,
+            UndefinedStereochemistryError,
+        )
         from rdkit import Chem
 
         for mol in ref_ligands:

--- a/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
+++ b/asapdiscovery-alchemy/asapdiscovery/alchemy/tests/test_utils.py
@@ -405,3 +405,32 @@ def test_get_cdd_molecules_util(monkeypatch, defined_only, n_ligands, remove_cov
     for ligand in molecules:
         assert ligand.tags["experimental"] == "True"
         assert ligand.tags["cdd_protocol"] == "my-protocol"
+
+
+def test_cdd_download_remove_radicals(monkeypatch):
+    """Make sure radical molecules are removed from downloaded protocols."""
+
+    import asapdiscovery.alchemy.predict
+
+    def get_cdd_data(protocol_name: str):
+        data = [
+            {"Smiles": "CCO", "Molecule Name": "ethanol", "CXSmiles": "CCO"},
+            {
+                "Smiles": "C[CH2]",
+                "Molecule Name": "radical",
+                "CXSmiles": "C[CH2]",
+            },
+        ]
+        return pandas.DataFrame(data)
+
+    monkeypatch.setattr(
+        asapdiscovery.alchemy.predict, "download_cdd_data", get_cdd_data
+    )
+
+    molecules = get_cdd_molecules(
+        protocol_name="my-protocol",
+        defined_stereo_only=True,
+        remove_covalent=True,
+    )
+    assert len(molecules) == 1
+    assert molecules[0].compound_name == "ethanol"

--- a/asapdiscovery-data/asapdiscovery/data/backend/rdkit.py
+++ b/asapdiscovery-data/asapdiscovery/data/backend/rdkit.py
@@ -136,7 +136,7 @@ def sdf_str_to_rdkit_mol(sdf: str) -> Chem.Mol:
     from io import BytesIO
 
     bio = BytesIO(sdf.encode())
-    suppl = Chem.ForwardSDMolSupplier(bio)
+    suppl = Chem.ForwardSDMolSupplier(bio, removeHs=False)
 
     ref = next(suppl)
     for mol in suppl:

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -190,6 +190,7 @@ class Ligand(DataModelAbstractBase):
         oechem.OEClearAromaticFlags(input_mol)
         oechem.OEAssignAromaticFlags(input_mol, oechem.OEAroModel_MDL)
         oechem.OEAssignHybridization(input_mol)
+        oechem.OEAddExplicitHydrogens(input_mol)
         kwargs.pop("data", None)
 
         conf_tags = get_SD_data(mol)

--- a/asapdiscovery-data/asapdiscovery/data/tests/conftest.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/conftest.py
@@ -68,6 +68,12 @@ def ligands(smiles):
     return [Ligand.from_smiles(s, compound_name="test") for s in smiles]
 
 
+@pytest.fixture(scope="module")
+def ligands_from_complexes(complexes):
+    # get ligands from 3d structure to ensure the added hydrogens make sense, using top 4 to match the smiles
+    return [c.ligand for c in complexes[0:4]]
+
+
 @pytest.fixture()
 def mocked_cdd_api():
     """A cdd_api configured with dummy data which should have the requests mocked."""

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_complex_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_complex_schema.py
@@ -26,7 +26,7 @@ def test_complex_from_pdb(complex_pdb):
     assert c.target.target_name == "test"
     assert c.ligand.compound_name == "test"
     assert c.target.to_oemol().NumAtoms() == 4716
-    assert c.ligand.to_oemol().NumAtoms() == 33
+    assert c.ligand.to_oemol().NumAtoms() == 53
 
 
 def test_equal(complex_pdb):

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
@@ -32,6 +32,9 @@ def test_from_smiles_ids_made(smiles):
     """Make sure the ligand provenance is automatically generated."""
     lig = Ligand.from_smiles(smiles, compound_name="test_name")
     assert lig.provenance.isomeric_smiles == smiles
+    # make sure hydrogens are added to the molecule
+    oemol = lig.to_oemol()
+    assert oemol.NumAtoms() == 23
 
 
 def test_from_oemol_sd_tags_left(moonshot_sdf):

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_selectors.py
@@ -11,63 +11,81 @@ from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.docking.docking import DockingInputPair  # TODO: move to data
 
 
-def test_pairwise_selector(ligands, complexes):
+def test_pairwise_selector(ligands_from_complexes, complexes):
     selector = PairwiseSelector()
-    pairs = selector.select(ligands, complexes)
+    pairs = selector.select(ligands_from_complexes, complexes)
     assert len(pairs) == 40
 
 
-def test_leave_one_out_selector(ligands, complexes):
+def test_leave_one_out_selector(ligands_from_complexes, complexes):
     selector = LeaveOneOutSelector()
-    pairs = selector.select(ligands, complexes)
+    pairs = selector.select(ligands_from_complexes, complexes)
     assert len(pairs) == 36
 
 
-def test_leave_similar_out_selector(ligands, complexes):
+def test_leave_similar_out_selector(ligands_from_complexes, complexes):
     selector = LeaveSimilarOutSelector()
-    pairs = selector.select(ligands, complexes)
+    pairs = selector.select(ligands_from_complexes, complexes)
     assert len(pairs) == 36
 
 
-def test_self_docking_selector(ligands, complexes):
+def test_self_docking_selector(ligands_from_complexes, complexes):
     selector = SelfDockingSelector()
-    pairs = selector.select(ligands, complexes)
+    pairs = selector.select(ligands_from_complexes, complexes)
     assert len(pairs) == 4
 
 
 @pytest.mark.parametrize("use_dask", [True, False])
-def test_pairwise_selector_prepped(ligands, prepped_complexes, use_dask):
+def test_pairwise_selector_prepped(ligands_from_complexes, prepped_complexes, use_dask):
     selector = PairwiseSelector()
-    pairs = selector.select(ligands, prepped_complexes, use_dask=use_dask)
+    pairs = selector.select(
+        ligands_from_complexes, prepped_complexes, use_dask=use_dask
+    )
     assert len(pairs) == 8
 
 
-def test_mcs_selector(ligands, complexes):
+def test_mcs_selector(ligands_from_complexes, complexes):
     selector = MCSSelector()
-    pairs = selector.select(ligands, complexes, n_select=1)
+    pairs = selector.select(ligands_from_complexes, complexes, n_select=1)
     # should be 4 pairs
     assert len(pairs) == 4
-    # as we matched against the exact smiles of the first 4 complex ligands, they should be in order
-    assert pairs[0] == CompoundStructurePair(ligand=ligands[0], complex=complexes[0])
-    assert pairs[1] == CompoundStructurePair(ligand=ligands[1], complex=complexes[1])
-    assert pairs[2] == CompoundStructurePair(ligand=ligands[2], complex=complexes[2])
-    assert pairs[3] == CompoundStructurePair(ligand=ligands[3], complex=complexes[3])
+    # as we matched against the exact smiles of the first 4 complex ligands_from_complexes, they should be in order
+    assert pairs[0] == CompoundStructurePair(
+        ligand=ligands_from_complexes[0], complex=complexes[0]
+    )
+    assert pairs[1] == CompoundStructurePair(
+        ligand=ligands_from_complexes[1], complex=complexes[1]
+    )
+    assert pairs[2] == CompoundStructurePair(
+        ligand=ligands_from_complexes[2], complex=complexes[2]
+    )
+    assert pairs[3] == CompoundStructurePair(
+        ligand=ligands_from_complexes[3], complex=complexes[3]
+    )
 
 
-def test_mcs_select_prepped(ligands, prepped_complexes):
+def test_mcs_select_prepped(ligands_from_complexes, prepped_complexes):
     selector = MCSSelector()
-    pairs = selector.select(ligands, prepped_complexes, n_select=1)
+    pairs = selector.select(ligands_from_complexes, prepped_complexes, n_select=1)
     # should be 4 pairs
     assert len(pairs) == 4
-    assert pairs[0] == DockingInputPair(ligand=ligands[0], complex=prepped_complexes[0])
-    assert pairs[1] == DockingInputPair(ligand=ligands[1], complex=prepped_complexes[1])
-    assert pairs[2] == DockingInputPair(ligand=ligands[2], complex=prepped_complexes[1])
-    assert pairs[3] == DockingInputPair(ligand=ligands[3], complex=prepped_complexes[0])
+    assert pairs[0] == DockingInputPair(
+        ligand=ligands_from_complexes[0], complex=prepped_complexes[0]
+    )
+    assert pairs[1] == DockingInputPair(
+        ligand=ligands_from_complexes[1], complex=prepped_complexes[1]
+    )
+    assert pairs[2] == DockingInputPair(
+        ligand=ligands_from_complexes[2], complex=prepped_complexes[1]
+    )
+    assert pairs[3] == DockingInputPair(
+        ligand=ligands_from_complexes[3], complex=prepped_complexes[0]
+    )
 
 
-def test_mcs_selector_nselect(ligands, complexes):
+def test_mcs_selector_nselect(ligands_from_complexes, complexes):
     selector = MCSSelector()
-    pairs = selector.select(ligands, complexes, n_select=2)
+    pairs = selector.select(ligands_from_complexes, complexes, n_select=2)
     # should be 8 pairs
     assert len(pairs) == 8
     assert (

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_sets.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_sets.py
@@ -4,11 +4,10 @@ from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.data.schema.sets import CompoundMultiStructure
 
 
-def test_multi_structure_from_pairs(ligands, complexes):
-    # I could use the pairwise selector but that makes it an integration test, right?
+def test_multi_structure_from_pairs(ligands_from_complexes, complexes):
     pairs = [
         CompoundStructurePair(ligand=ligand, complex=complex)
-        for ligand, complex in product(ligands, complexes)
+        for ligand, complex in product(ligands_from_complexes, complexes)
     ]
     assert len(pairs) == 40
     multi_structures = CompoundMultiStructure.from_pairs(pairs)
@@ -22,11 +21,11 @@ def test_multi_structure_from_pairs(ligands, complexes):
 
     assert (
         multi_structures[0].unique_name
-        == "test-KTTFDHLIVPVQIE-UHFFFAOYNA-N_0bf8638845b542d72ce3375b24f0c5757fccc4e8f11b2eb65d838acc41508a16"
+        == "test-KTTFDHLIVPVQIE-UHFFFAOYNA-N_de2fc89d89986c55d83706d99acce170a34caebb3cc1de6d2a0780b9c1a9fd7f"
     )
     assert (
         multi_structures[1].unique_name
-        == "test-AVCQLYXAEKNILW-UHFFFAOYNA-N_0bf8638845b542d72ce3375b24f0c5757fccc4e8f11b2eb65d838acc41508a16"
+        == "test-AVCQLYXAEKNILW-UHFFFAOYNA-N_de2fc89d89986c55d83706d99acce170a34caebb3cc1de6d2a0780b9c1a9fd7f"
     )
 
     # the ligands should be different, but the complexes should be the same

--- a/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/schema/pose_generation.py
@@ -270,6 +270,9 @@ class OpenEyeConstrainedPoseGenerator(_BasicConstrainedPoseGenerator):
             An OEGraphMol of the MCS matched core fragment.
         """
 
+        # work with a copy and remove the hydrogens from the reference as we dont want to constrain to them
+        input_mol = oechem.OEMol(reference_ligand)
+        oechem.OESuppressHydrogens(input_mol)
         # build a query mol which allows for wild card matches
         # <https://github.com/choderalab/asapdiscovery/pull/430#issuecomment-1702360130>
         smarts_mol = oechem.OEGraphMol()
@@ -279,10 +282,10 @@ class OpenEyeConstrainedPoseGenerator(_BasicConstrainedPoseGenerator):
         bondexpr = oechem.OEExprOpts_DefaultBonds
         pattern_query.BuildExpressions(atomexpr, bondexpr)
         ss = oechem.OESubSearch(pattern_query)
-        oechem.OEPrepareSearch(reference_ligand, ss)
+        oechem.OEPrepareSearch(input_mol, ss)
         core_fragment = None
 
-        for match in ss.Match(reference_ligand):
+        for match in ss.Match(input_mol):
             core_fragment = oechem.OEGraphMol()
             oechem.OESubsetMol(core_fragment, match)
             break

--- a/asapdiscovery-docking/asapdiscovery/docking/tests/test_pose_generation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/tests/test_pose_generation.py
@@ -1,5 +1,5 @@
 import pytest
-from asapdiscovery.data.backend.openeye import get_SD_data, oechem, oemol_to_inchikey
+from asapdiscovery.data.backend.openeye import get_SD_data, oechem, oemol_to_inchikey, oemol_to_smiles
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.docking.schema.pose_generation import (
     OpenEyeConstrainedPoseGenerator,

--- a/asapdiscovery-docking/asapdiscovery/docking/tests/test_pose_generation.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/tests/test_pose_generation.py
@@ -1,5 +1,5 @@
 import pytest
-from asapdiscovery.data.backend.openeye import get_SD_data, oechem, oemol_to_inchikey, oemol_to_smiles
+from asapdiscovery.data.backend.openeye import get_SD_data, oechem, oemol_to_inchikey
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.docking.schema.pose_generation import (
     OpenEyeConstrainedPoseGenerator,

--- a/asapdiscovery-ml/asapdiscovery/ml/models.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.py
@@ -218,8 +218,8 @@ class MLModelRegistry(BaseModel):
                 f"Target {target} not valid, must be one of {TargetTags.get_values()}"
             )
         return [model for model in self.models.values() if target in model.targets]
-    
-    def get_targets_with_models(self) -> List[TargetTags]:
+
+    def get_targets_with_models(self) -> list[TargetTags]:
         """
         Get all targets with models
 
@@ -228,7 +228,9 @@ class MLModelRegistry(BaseModel):
         List[TargetTags]
             List of targets with models
         """
-        return list({target.value for model in self.models.values() for target in model.targets})
+        return list(
+            {target.value for model in self.models.values() for target in model.targets}
+        )
 
     def get_latest_model_for_target_and_type(
         self, target: TargetTags, type: ModelType


### PR DESCRIPTION
## Description
This PR adds a check to remove radical molecules from the cdd downloader in asap-alchemy to make sure such molecules are not used as experimental references in FEC networks. We also make sure ligands created from smiles have explicit hydrogens. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Remove radicals from CDD download
- [x] make sure molecules from smiles have explicit hydrogens.

## Questions
- [ ] Question 1 ..

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
