### PR TITLE
hotfix subtle change to invariant in sdf_str function

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
@@ -661,11 +661,15 @@ def sdf_string_to_oemol(sdf_str: str) -> oechem.OEMol:
         oechem.OEFormat_SDF,
         oechem.OEIFlavor_SDF_Default,
     )
+    rmol = oechem.OEMol()
     ims.SetConfTest(oechem.OEOmegaConfTest())
     if ims.openstring(sdf_str):
+
         for mol in ims.GetOEMols():
-            ims.close()
-            return mol
+            rmol = mol.CreateCopy()
+            break # only return the first molecule
+    return rmol
+
 
 
 def smiles_to_oemol(smiles: str) -> oechem.OEMol:

--- a/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
@@ -667,9 +667,8 @@ def sdf_string_to_oemol(sdf_str: str) -> oechem.OEMol:
 
         for mol in ims.GetOEMols():
             rmol = mol.CreateCopy()
-            break # only return the first molecule
+            break  # only return the first molecule
     return rmol
-
 
 
 def smiles_to_oemol(smiles: str) -> oechem.OEMol:


### PR DESCRIPTION
Fixes #1000 

@apayne97  this was a subtle change in the `sdf_string_to_oemol` function such that it could now return `None` if no valid molecules were read. Related to #998, I am going to hotfix here, we can continue discussion about what the desired endstate should be there. 

The basic info though is that all of our `openeye` functions currently return an `OEMol` always, even if a read failed (making it the callee's responsibility to check if the OEMol is valid for their purpose.

 If we change this so that the read will fail instead every call site has to check for success. This is doable and we can discuss. 

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
