### PR TITLE
`asap-docking` | Correctly save multipose docking results

### DIFF
--- a/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
+++ b/asapdiscovery-data/asapdiscovery/data/backend/openeye.py
@@ -964,7 +964,7 @@ def print_SD_data(mol: oechem.OEMol) -> None:
         print(dp.GetTag(), ":", dp.GetValue())
 
 
-def clear_SD_data(mol: oechem.OEMol) -> oechem.OEMol:
+def clear_SD_data(mol: oechem.OEMolBase) -> oechem.OEMol:
     """
     Clear all SD data on an OpenEye OEMol
 
@@ -978,8 +978,11 @@ def clear_SD_data(mol: oechem.OEMol) -> oechem.OEMol:
     oechem.OEMol
         OpenEye OEMol with SD data cleared
     """
-    for conf in mol.GetConfs():
-        oechem.OEClearSDData(conf)
+    oechem.OEClearSDData(mol)
+
+    if isinstance(mol, oechem.OEMCMolBase):
+        for conf in mol.GetConfs():
+            oechem.OEClearSDData(conf)
     return mol
 
 

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -261,6 +261,32 @@ class Ligand(DataModelAbstractBase):
 
         return mol
 
+    @classmethod
+    def from_single_conformers(cls, confs: list["Ligand"]) -> ["Ligand"]:
+        """
+        Create a Ligand object from a list of Ligand objects, each representing a single conformer.
+
+        This is a bit complicated because we want to ensure that the resulting Ligand object
+        has the same data as all the original conformers.
+        """
+        # check that all the conformers are the same
+        if not all([confs[0].is_chemically_equal(conf) for conf in confs]):
+            raise InvalidLigandError(
+                "All conformers must have the same chemical structure data"
+            )
+
+        # get the data from the first conformer
+        data = confs[0].data
+        # get the tags from all the conformers
+        tags = {}
+        conf_tags = {}
+        for conf in confs:
+            tags.update(conf.tags)
+            conf_tags.update(conf.conf_tags)
+
+        # create a new Ligand object with the data from the first conformer
+        return cls(data=data, tags=tags, conf_tags=conf_tags)
+
     def to_single_conformers(self) -> ["Ligand"]:
         """
         Return a Ligand object for each conformer.

--- a/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
+++ b/asapdiscovery-data/asapdiscovery/data/schema/ligand.py
@@ -287,7 +287,6 @@ class Ligand(DataModelAbstractBase):
         from asapdiscovery.data.util.data_conversion import (
             get_dict_of_lists_from_list_of_dicts,
         )
-        from asapdiscovery.data.backend.openeye import get_SD_data
 
         conf_tags = get_dict_of_lists_from_list_of_dicts([tags] + sd_data)
         conf_tags = {
@@ -296,9 +295,7 @@ class Ligand(DataModelAbstractBase):
 
         # create a new Ligand object with the data from the first conformer
         new_lig = cls.from_oemol(oemol)
-        import pdb
 
-        pdb.set_trace()
         new_lig.set_SD_data(conf_tags)
         return new_lig
 

--- a/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
+++ b/asapdiscovery-data/asapdiscovery/data/tests/test_ligand_schema.py
@@ -127,7 +127,7 @@ def test_ligand_from_sdf_title_used(moonshot_sdf):
     assert lig.compound_name == "Mpro-P0008_0A_ERI-UCB-ce40166b-17"
 
 
-def test_multi_pose_ligand_sdf_roundtrip(multipose_ligand, tmp_path):
+def test_multiconformer_ligand_sdf_roundtrip(multipose_ligand, tmp_path):
     lig = Ligand.from_sdf(multipose_ligand)
     assert lig.num_poses == 50
 
@@ -139,7 +139,7 @@ def test_multi_pose_ligand_sdf_roundtrip(multipose_ligand, tmp_path):
     assert lig2 == lig
 
 
-def test_multi_pose_ligand_json_roundtrip(multipose_ligand, tmp_path):
+def test_multiconformer_ligand_json_roundtrip(multipose_ligand, tmp_path):
     lig = Ligand.from_sdf(multipose_ligand)
     assert lig.num_poses == 50
 
@@ -149,6 +149,19 @@ def test_multi_pose_ligand_json_roundtrip(multipose_ligand, tmp_path):
 
     assert lig2.num_poses == 50
     assert lig2 == lig
+
+
+def test_single_conformers_roundtrip(multipose_ligand, tmp_path):
+    lig = Ligand.from_sdf(multipose_ligand)
+    ligs = lig.to_single_conformers()
+    assert len(ligs) == 50
+
+    newlig = Ligand.from_single_conformers(ligs)
+
+    assert newlig == lig
+    assert newlig.tags == lig.tags
+    assert newlig.conf_tags == lig.conf_tags
+    assert newlig.data == lig.data
 
 
 def test_multiconf_ligand_basics(multipose_ligand):
@@ -485,6 +498,16 @@ def test_get_set_sd_data(moonshot_sdf):
     l1.set_SD_data(data)
     data_pulled = l1.get_single_conf_SD_data()
     assert all(data_pulled[key] == data_roundtrip[key] for key in data_roundtrip.keys())
+
+
+def test_set_SD_data_empty(moonshot_sdf):
+    # shouldn't change the data
+    l1 = Ligand.from_sdf(moonshot_sdf, compound_name="blahblah")
+    l2 = Ligand.from_sdf(moonshot_sdf, compound_name="blahblah2")
+    data = {}
+    l2.set_SD_data(data)
+    assert l1.tags == l2.tags
+    assert l1.conf_tags == l2.conf_tags
 
 
 def test_print_sd_data(moonshot_sdf):

--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -290,6 +290,36 @@ class DockingResult(BaseModel):
         return not self.__eq__(other)
 
 
+class MultiPoseDockingResult(BaseModel):
+    """
+    Schema for a MultiPoseDockingResult, containing both a DockingInputPair used as input to the workflow
+    and a Ligand object containing the docked poses.
+
+    Parameters
+    ----------
+    input_pair : DockingInputPair
+        Input pair
+    ligand : Ligand
+        Ligand object with multiple docked poses
+    provenance : dict[str, str]
+        Provenance information
+    """
+
+    type: Literal["DockingResult"] = "MultiPoseDockingResult"
+    input_pair: DockingInputPair = Field(description="Input pair")
+    posed_ligand: Ligand = Field(description="Posed ligand")
+    provenance: dict[str, str] = Field(description="Provenance")
+
+    def to_json_file(self, file: str | Path):
+        with open(file, "w") as f:
+            f.write(self.json(indent=2))
+
+    @classmethod
+    def from_json_file(cls, file: str | Path) -> "MultiPoseDockingResult":
+        with open(file) as f:
+            return cls.parse_raw(f.read())
+
+
 def write_results_to_multi_sdf(
     sdf_file: Union[str, Path],
     results: Union[list[DockingResult], list[Path]],

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -291,7 +291,6 @@ class POSITDocker(DockingBase):
                         pose_res, retcode = self.run_oe_posit_docking(
                             opts, pose_res, dus, lig_oemol, self.num_poses
                         )
-
                 if retcode == oedocking.OEDockingReturnCode_Success:
                     for result in pose_res.GetSinglePoseResults():
                         posed_mol = result.GetPose()


### PR DESCRIPTION
## Description
Updates the POSIT docker to use the updates from #692 to handle writing multipose posit results. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] add tests and functionality for creating a new ligand object from multiple separate ligand objects with the same chemical identity
- [ ] update the POSITDocker to use this and pass all the results to a single results obj
- [ ] update the dataframe + postera + etc endpoint writers

## Questions
- [ ] Question 1 ..

## Status
- [ ] Ready to go


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
