### PR TITLE
Add resilience to non-dask computation

### DIFF
--- a/asapdiscovery-cli/asapdiscovery/cli/cli_args.py
+++ b/asapdiscovery-cli/asapdiscovery/cli/cli_args.py
@@ -1,6 +1,6 @@
 import click
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import DaskFailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
 from asapdiscovery.ml.models import ASAPMLModelRegistry
 from asapdiscovery.simulation.simulate import OpenMMPlatform
 
@@ -54,18 +54,18 @@ def dask_type(func):
     )(func)
 
 
-def dask_failure_mode(func):
+def failure_mode(func):
     return click.option(
-        "--dask-failure-mode",
-        type=click.Choice(DaskFailureMode.get_values(), case_sensitive=False),
-        default=DaskFailureMode.SKIP,
+        "--failure-mode",
+        type=click.Choice(FailureMode.get_values(), case_sensitive=False),
+        default=FailureMode.SKIP,
         help="The failure mode for dask. Can be 'raise' or 'skip'.",
         show_default=True,
     )(func)
 
 
 def dask_args(func):
-    return use_dask(dask_type(dask_failure_mode(func)))
+    return use_dask(dask_type(failure_mode(func)))
 
 
 def target(func):

--- a/asapdiscovery-cli/asapdiscovery/cli/cli_args.py
+++ b/asapdiscovery-cli/asapdiscovery/cli/cli_args.py
@@ -1,6 +1,6 @@
 import click
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import DaskType, FailureMode
 from asapdiscovery.ml.models import ASAPMLModelRegistry
 from asapdiscovery.simulation.simulate import OpenMMPlatform
 

--- a/asapdiscovery-data/asapdiscovery/data/operators/selectors/selector.py
+++ b/asapdiscovery-data/asapdiscovery/data/operators/selectors/selector.py
@@ -6,7 +6,7 @@ from asapdiscovery.data.schema.complex import Complex, PreppedComplex
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.data.util.dask_utils import (
-    DaskFailureMode,
+    FailureMode,
     actualise_dask_delayed_iterable,
 )
 from asapdiscovery.docking.docking import DockingInputPair  # TODO: move to backend
@@ -31,7 +31,7 @@ class SelectorBase(abc.ABC, BaseModel):
         complexes: list[Union[Complex, PreppedComplex]],
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         **kwargs,
     ) -> list[Union[CompoundStructurePair, DockingInputPair]]:
         if use_dask:
@@ -43,7 +43,7 @@ class SelectorBase(abc.ABC, BaseModel):
                 # see # 560
                 delayed_outputs.append(out)
             outputs = actualise_dask_delayed_iterable(
-                delayed_outputs, dask_client, errors=dask_failure_mode
+                delayed_outputs, dask_client, errors=failure_mode
             )
             outputs = [
                 item for sublist in outputs for item in sublist

--- a/asapdiscovery-data/asapdiscovery/data/readers/meta_structure_factory.py
+++ b/asapdiscovery-data/asapdiscovery/data/readers/meta_structure_factory.py
@@ -5,7 +5,7 @@ from typing import Optional
 from asapdiscovery.data.readers.structure_dir import StructureDirFactory
 from asapdiscovery.data.schema.complex import Complex
 from asapdiscovery.data.services.fragalysis.fragalysis_reader import FragalysisFactory
-from asapdiscovery.data.util.dask_utils import DaskFailureMode
+from asapdiscovery.data.util.dask_utils import FailureMode
 from pydantic import BaseModel, Field, root_validator
 
 logger = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ class MetaStructureFactory(BaseModel):
         self,
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode: DaskFailureMode = DaskFailureMode.SKIP,
+        failure_mode: FailureMode = FailureMode.SKIP,
     ) -> list[Complex]:
         # load complexes from a directory, from fragalysis or from a pdb file
         if self.structure_dir:
@@ -64,7 +64,7 @@ class MetaStructureFactory(BaseModel):
             complexes = structure_factory.load(
                 use_dask=use_dask,
                 dask_client=dask_client,
-                dask_failure_mode=dask_failure_mode,
+                failure_mode=failure_mode,
             )
         elif self.fragalysis_dir:
             logger.info(f"Loading structures from fragalysis: {self.fragalysis_dir}")
@@ -72,7 +72,7 @@ class MetaStructureFactory(BaseModel):
             complexes = fragalysis.load(
                 use_dask=use_dask,
                 dask_client=dask_client,
-                dask_failure_mode=dask_failure_mode,
+                failure_mode=failure_mode,
             )
 
         elif self.pdb_file:

--- a/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
+++ b/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
@@ -5,7 +5,7 @@ from typing import List  # noqa: F401
 import dask
 from asapdiscovery.data.schema.complex import Complex
 from asapdiscovery.data.util.dask_utils import (
-    DaskFailureMode,
+    FailureMode,
     actualise_dask_delayed_iterable,
 )
 from pydantic import BaseModel, Field, validator
@@ -41,7 +41,7 @@ class StructureDirFactory(BaseModel):
         return cls(parent_dir=Path(parent_dir))
 
     def load(
-        self, use_dask=True, dask_client=None, dask_failure_mode=DaskFailureMode.SKIP
+        self, use_dask=True, dask_client=None, failure_mode=FailureMode.SKIP
     ):
         """
         Load a directory of PDB files as Complex objects.
@@ -53,7 +53,7 @@ class StructureDirFactory(BaseModel):
             Defaults to True.
         dask_client : dask.distributed.Client, optional
             Dask client to use for parallelisation. Defaults to None.
-        dask_failure_mode : DaskFailureMode
+        failure_mode : FailureMode
             The failure mode for dask. Can be 'raise' or 'skip'.
 
         Returns
@@ -81,7 +81,7 @@ class StructureDirFactory(BaseModel):
                 )
                 delayed_outputs.append(out)
             outputs = actualise_dask_delayed_iterable(
-                delayed_outputs, dask_client, errors=dask_failure_mode
+                delayed_outputs, dask_client, errors=failure_mode
             )
         else:
             outputs = []

--- a/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
+++ b/asapdiscovery-data/asapdiscovery/data/readers/structure_dir.py
@@ -40,9 +40,7 @@ class StructureDirFactory(BaseModel):
         """
         return cls(parent_dir=Path(parent_dir))
 
-    def load(
-        self, use_dask=True, dask_client=None, failure_mode=FailureMode.SKIP
-    ):
+    def load(self, use_dask=True, dask_client=None, failure_mode=FailureMode.SKIP):
         """
         Load a directory of PDB files as Complex objects.
 

--- a/asapdiscovery-data/asapdiscovery/data/services/fragalysis/fragalysis_reader.py
+++ b/asapdiscovery-data/asapdiscovery/data/services/fragalysis/fragalysis_reader.py
@@ -9,7 +9,7 @@ import dask
 import pandas
 from asapdiscovery.data.schema.complex import Complex
 from asapdiscovery.data.util.dask_utils import (
-    DaskFailureMode,
+    FailureMode,
     actualise_dask_delayed_iterable,
 )
 from pydantic import BaseModel, Field, root_validator, validator
@@ -69,7 +69,7 @@ class FragalysisFactory(BaseModel):
         return values
 
     def load(
-        self, use_dask=False, dask_client=None, dask_failure_mode=DaskFailureMode.SKIP
+        self, use_dask=False, dask_client=None, failure_mode=FailureMode.SKIP
     ) -> list[Complex]:
         """
         Load a Fragalysis dump as a list of Complex objects.
@@ -81,7 +81,7 @@ class FragalysisFactory(BaseModel):
             Defaults to False.
         dask_client : dask.distributed.Client, optional
             Dask client to use for parallelisation. Defaults to None.
-        dask_failure_mode : DaskFailureMode
+        failure_mode : FailureMode
             The failure mode for dask. Can be 'raise' or 'skip'.
 
         Returns
@@ -132,7 +132,7 @@ class FragalysisFactory(BaseModel):
 
         if use_dask:
             complexes = actualise_dask_delayed_iterable(
-                complexes, dask_client=dask_client, errors=dask_failure_mode
+                complexes, dask_client=dask_client, errors=failure_mode
             )
 
         # remove None values

--- a/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
@@ -165,9 +165,7 @@ def dask_vmap(kwargsnames, remove_falsy=True, has_failure_mode=False):
             # grab optional dask kwargs
             use_dask = kwargs.pop("use_dask", None)
             dask_client = kwargs.pop("dask_client", None)
-            failure_mode = kwargs.pop(
-                "failure_mode", FailureMode.SKIP.value
-            )
+            failure_mode = kwargs.pop("failure_mode", FailureMode.SKIP.value)
 
             if use_dask:
                 # grab iterable_kwargs

--- a/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import operator
 from collections.abc import Iterable
 from typing import Optional, Union
 

--- a/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
+++ b/asapdiscovery-data/asapdiscovery/data/util/dask_utils.py
@@ -1,14 +1,12 @@
 import functools
 import logging
+import operator
 from collections.abc import Iterable
 from typing import Optional, Union
 
 import dask
 import numpy as np
 import psutil
-import functools
-import operator
-
 from asapdiscovery.data.util.execution_utils import (
     get_platform,
     guess_network_interface,

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -324,55 +324,68 @@ class GIFVisualizer(VisualizerBase):
         self,
         inputs: list[SimulationResult],
         outpaths: Optional[list[Path]] = None,
+        error: str = "skip",
         **kwargs,
     ):
         data = []
 
         for i, res in enumerate(inputs):
-            if not outpaths:
-                if self.static_view_only:
-                    out = (
-                        self.output_dir
-                        / res.input_docking_result.unique_name
-                        / "view.pse"
-                    )
+            try:
+                if not outpaths:
+                    if self.static_view_only:
+                        out = (
+                            self.output_dir
+                            / res.input_docking_result.unique_name
+                            / "view.pse"
+                        )
+                    else:
+                        out = (
+                            self.output_dir
+                            / res.input_docking_result.unique_name
+                            / "trajectory.gif"
+                        )
                 else:
-                    out = (
-                        self.output_dir
-                        / res.input_docking_result.unique_name
-                        / "trajectory.gif"
-                    )
-            else:
-                out = self.output_dir / outpaths[i]
+                    out = self.output_dir / outpaths[i]
 
-            path = self.pymol_traj_viz(
-                target=self.target,
-                traj=res.traj_path,
-                system=res.minimized_pdb_path,
-                outpath=out,
-                static_view_only=self.static_view_only,
-                pse=self.pse,
-                pse_share=self.pse_share,
-                start=self.start,
-                stop=self.stop,
-                interval=self.interval,
-                smooth=self.smooth,
-                contacts=self.contacts,
-                frames_per_ns=self.frames_per_ns,
-                out_dir=self.output_dir,
-            )
-            row = {}
-            row[DockingResultCols.LIGAND_ID.value] = (
-                res.input_docking_result.posed_ligand.compound_name
-            )
-            row[DockingResultCols.TARGET_ID.value] = (
-                res.input_docking_result.input_pair.complex.target.target_name
-            )
-            row[DockingResultCols.SMILES.value] = (
-                res.input_docking_result.posed_ligand.smiles
-            )
-            row[DockingResultCols.GIF_PATH.value] = path
-            data.append(row)
+                path = self.pymol_traj_viz(
+                    target=self.target,
+                    traj=res.traj_path,
+                    system=res.minimized_pdb_path,
+                    outpath=out,
+                    static_view_only=self.static_view_only,
+                    pse=self.pse,
+                    pse_share=self.pse_share,
+                    start=self.start,
+                    stop=self.stop,
+                    interval=self.interval,
+                    smooth=self.smooth,
+                    contacts=self.contacts,
+                    frames_per_ns=self.frames_per_ns,
+                    out_dir=self.output_dir,
+                )
+                row = {}
+                row[
+                    DockingResultCols.LIGAND_ID.value
+                ] = res.input_docking_result.posed_ligand.compound_name
+                row[
+                    DockingResultCols.TARGET_ID.value
+                ] = res.input_docking_result.input_pair.complex.target.target_name
+                row[
+                    DockingResultCols.SMILES.value
+                ] = res.input_docking_result.posed_ligand.smiles
+                row[DockingResultCols.GIF_PATH.value] = path
+                data.append(row)
+            except Exception as e:
+                if error == "skip":
+                    logger.error(
+                        f"Error processing {res.input_docking_result.unique_name}: {e}"
+                    )
+                elif error == "raise":
+                    raise e
+                else:
+                    raise ValueError(
+                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                    )
         return data
 
     @_dispatch.register
@@ -380,49 +393,60 @@ class GIFVisualizer(VisualizerBase):
         self,
         inputs: list[tuple[Optional[Path], Path]],
         outpaths: Optional[list[Path]] = None,
+        error: str = "skip",
         **kwargs,
     ):
         data = []
         for i, tup in enumerate(inputs):
-            # unpack the tuple
-            traj, top = tup
-            # find with the unique identifier for the ligand would be
-            complex = Complex.from_pdb(
-                top,
-                target_kwargs={"target_name": f"{top.stem}_target"},
-                ligand_kwargs={"compound_name": f"{top.stem}_ligand"},
-            )
-            csp = CompoundStructurePair(complex=complex, ligand=complex.ligand)
-            if not outpaths:
-                if self.static_view_only:
-                    out = self.output_dir / csp.unique_name / "view.pse"
+            try:
+                # unpack the tuple
+                traj, top = tup
+                # find with the unique identifier for the ligand would be
+                complex = Complex.from_pdb(
+                    top,
+                    target_kwargs={"target_name": f"{top.stem}_target"},
+                    ligand_kwargs={"compound_name": f"{top.stem}_ligand"},
+                )
+                csp = CompoundStructurePair(complex=complex, ligand=complex.ligand)
+                if not outpaths:
+                    if self.static_view_only:
+                        out = self.output_dir / csp.unique_name / "view.pse"
+                    else:
+                        out = self.output_dir / csp.unique_name / "trajectory.gif"
                 else:
-                    out = self.output_dir / csp.unique_name / "trajectory.gif"
-            else:
-                out = self.output_dir / outpaths[i]
+                    out = self.output_dir / outpaths[i]
 
-            path = self.pymol_traj_viz(
-                target=self.target,
-                traj=traj,
-                system=top,
-                outpath=out,
-                static_view_only=self.static_view_only,
-                pse=self.pse,
-                pse_share=self.pse_share,
-                start=self.start,
-                stop=self.stop,
-                interval=self.interval,
-                smooth=self.smooth,
-                contacts=self.contacts,
-                frames_per_ns=self.frames_per_ns,
-                out_dir=self.output_dir,
-            )
-            row = {}
-            row[DockingResultCols.LIGAND_ID.value] = complex.ligand.compound_name
-            row[DockingResultCols.TARGET_ID.value] = complex.target.target_name
-            row[DockingResultCols.SMILES.value] = complex.ligand.smiles
-            row[DockingResultCols.GIF_PATH.value] = path
-            data.append(row)
+                path = self.pymol_traj_viz(
+                    target=self.target,
+                    traj=traj,
+                    system=top,
+                    outpath=out,
+                    static_view_only=self.static_view_only,
+                    pse=self.pse,
+                    pse_share=self.pse_share,
+                    start=self.start,
+                    stop=self.stop,
+                    interval=self.interval,
+                    smooth=self.smooth,
+                    contacts=self.contacts,
+                    frames_per_ns=self.frames_per_ns,
+                    out_dir=self.output_dir,
+                )
+                row = {}
+                row[DockingResultCols.LIGAND_ID.value] = complex.ligand.compound_name
+                row[DockingResultCols.TARGET_ID.value] = complex.target.target_name
+                row[DockingResultCols.SMILES.value] = complex.ligand.smiles
+                row[DockingResultCols.GIF_PATH.value] = path
+                data.append(row)
+            except Exception as e:
+                if error == "skip":
+                    logger.error(f"Error processing {csp.unique_name}: {e}")
+                elif error == "raise":
+                    raise e
+                else:
+                    raise ValueError(
+                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                    )
         return data
 
 

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -90,7 +90,7 @@ class GIFVisualizer(VisualizerBase):
     class Config:
         arbitrary_types_allowed = True
 
-    @dask_vmap(["inputs"])
+    @dask_vmap(["inputs"], has_failure_mode=True)
     def _visualize(
         self, inputs: list[Any], outpaths: Optional[list[Path]] = None, **kwargs
     ) -> list[dict[str, str]]:
@@ -324,7 +324,7 @@ class GIFVisualizer(VisualizerBase):
         self,
         inputs: list[SimulationResult],
         outpaths: Optional[list[Path]] = None,
-        error: str = "skip",
+        failure_mode: str = "skip",
         **kwargs,
     ):
         data = []
@@ -376,15 +376,15 @@ class GIFVisualizer(VisualizerBase):
                 row[DockingResultCols.GIF_PATH.value] = path
                 data.append(row)
             except Exception as e:
-                if error == "skip":
+                if failure_mode == "skip":
                     logger.error(
                         f"Error processing {res.input_docking_result.unique_name}: {e}"
                     )
-                elif error == "raise":
+                elif failure_mode == "raise":
                     raise e
                 else:
                     raise ValueError(
-                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
                     )
         return data
 
@@ -393,7 +393,7 @@ class GIFVisualizer(VisualizerBase):
         self,
         inputs: list[tuple[Optional[Path], Path]],
         outpaths: Optional[list[Path]] = None,
-        error: str = "skip",
+        failure_mode: str = "skip",
         **kwargs,
     ):
         data = []
@@ -439,13 +439,13 @@ class GIFVisualizer(VisualizerBase):
                 row[DockingResultCols.GIF_PATH.value] = path
                 data.append(row)
             except Exception as e:
-                if error == "skip":
+                if failure_mode == "skip":
                     logger.error(f"Error processing {csp.unique_name}: {e}")
-                elif error == "raise":
+                elif failure_mode == "raise":
                     raise e
                 else:
                     raise ValueError(
-                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
                     )
         return data
 

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/gif_viz.py
@@ -364,15 +364,15 @@ class GIFVisualizer(VisualizerBase):
                     out_dir=self.output_dir,
                 )
                 row = {}
-                row[
-                    DockingResultCols.LIGAND_ID.value
-                ] = res.input_docking_result.posed_ligand.compound_name
-                row[
-                    DockingResultCols.TARGET_ID.value
-                ] = res.input_docking_result.input_pair.complex.target.target_name
-                row[
-                    DockingResultCols.SMILES.value
-                ] = res.input_docking_result.posed_ligand.smiles
+                row[DockingResultCols.LIGAND_ID.value] = (
+                    res.input_docking_result.posed_ligand.compound_name
+                )
+                row[DockingResultCols.TARGET_ID.value] = (
+                    res.input_docking_result.input_pair.complex.target.target_name
+                )
+                row[DockingResultCols.SMILES.value] = (
+                    res.input_docking_result.posed_ligand.smiles
+                )
                 row[DockingResultCols.GIF_PATH.value] = path
                 data.append(row)
             except Exception as e:

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -211,12 +211,12 @@ class HTMLVisualizer(VisualizerBase):
 
                 # make dataframe with ligand name, target name, and path to HTML
                 row = {}
-                row[
-                    DockingResultCols.LIGAND_ID.value
-                ] = result.input_pair.ligand.compound_name
-                row[
-                    DockingResultCols.TARGET_ID.value
-                ] = result.input_pair.complex.target.target_name
+                row[DockingResultCols.LIGAND_ID.value] = (
+                    result.input_pair.ligand.compound_name
+                )
+                row[DockingResultCols.TARGET_ID.value] = (
+                    result.input_pair.complex.target.target_name
+                )
                 row[DockingResultCols.SMILES.value] = result.input_pair.ligand.smiles
                 row[self.get_tag_for_color_method()] = outpath
                 data.append(row)

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -168,6 +168,7 @@ class HTMLVisualizer(VisualizerBase):
         self,
         inputs: list[DockingResult],
         outpaths: Optional[list[Path]] = None,
+        error: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
@@ -189,35 +190,45 @@ class HTMLVisualizer(VisualizerBase):
         viz_data = []
 
         for i, result in enumerate(inputs):
-            output_pref = result.unique_name
-            if self.write_to_disk:
-                if not outpaths:
-                    outpath = self.output_dir / output_pref / "pose.html"
+            try:
+                output_pref = result.unique_name
+                if self.write_to_disk:
+                    if not outpaths:
+                        outpath = self.output_dir / output_pref / "pose.html"
+                    else:
+                        outpath = self.output_dir / Path(outpaths[i])
+                    outpath.parent.mkdir(parents=True, exist_ok=True)
                 else:
-                    outpath = self.output_dir / Path(outpaths[i])
-                outpath.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                outpath = None  # we don't need to write to disk
+                    outpath = None  # we don't need to write to disk
 
-            viz = self.html_pose_viz(
-                poses=[result.posed_ligand.to_oemol()], protein=result.to_protein()
-            )
-            viz_data.append(viz)
-            # write to disk
-            if self.write_to_disk:
-                self.write_html(viz, outpath)
+                viz = self.html_pose_viz(
+                    poses=[result.posed_ligand.to_oemol()], protein=result.to_protein()
+                )
+                viz_data.append(viz)
+                # write to disk
+                if self.write_to_disk:
+                    self.write_html(viz, outpath)
 
-            # make dataframe with ligand name, target name, and path to HTML
-            row = {}
-            row[DockingResultCols.LIGAND_ID.value] = (
-                result.input_pair.ligand.compound_name
-            )
-            row[DockingResultCols.TARGET_ID.value] = (
-                result.input_pair.complex.target.target_name
-            )
-            row[DockingResultCols.SMILES.value] = result.input_pair.ligand.smiles
-            row[self.get_tag_for_color_method()] = outpath
-            data.append(row)
+                # make dataframe with ligand name, target name, and path to HTML
+                row = {}
+                row[
+                    DockingResultCols.LIGAND_ID.value
+                ] = result.input_pair.ligand.compound_name
+                row[
+                    DockingResultCols.TARGET_ID.value
+                ] = result.input_pair.complex.target.target_name
+                row[DockingResultCols.SMILES.value] = result.input_pair.ligand.smiles
+                row[self.get_tag_for_color_method()] = outpath
+                data.append(row)
+            except Exception as e:
+                if error == "skip":
+                    logger.error(f"Error processing {result.unique_name}: {e}")
+                elif error == "raise":
+                    raise e
+                else:
+                    raise ValueError(
+                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                    )
 
         if self.write_to_disk:
             return data
@@ -257,7 +268,11 @@ class HTMLVisualizer(VisualizerBase):
 
     @_dispatch.register
     def _dispatch(
-        self, inputs: list[Complex], outpaths: Optional[list[Path]] = None, **kwargs
+        self,
+        inputs: list[Complex],
+        outpaths: Optional[list[Path]] = None,
+        error: str = "skip",
+        **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
         Implementation for a list of Complex objects.
@@ -277,33 +292,43 @@ class HTMLVisualizer(VisualizerBase):
         data = []
         viz_data = []
         for i, cmplx in enumerate(inputs):
-            if self.write_to_disk:
-                if not outpaths:
-                    output_pref = cmplx.unique_name
-                    outpath = self.output_dir / output_pref / "pose.html"
+            try:
+                if self.write_to_disk:
+                    if not outpaths:
+                        output_pref = cmplx.unique_name
+                        outpath = self.output_dir / output_pref / "pose.html"
+                    else:
+                        outpath = self.output_dir / Path(outpaths[i])
+
+                    outpath.parent.mkdir(parents=True, exist_ok=True)
                 else:
-                    outpath = self.output_dir / Path(outpaths[i])
+                    outpath = None
 
-                outpath.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                outpath = None
+                # make html string
+                viz = self.html_pose_viz(
+                    poses=[cmplx.ligand.to_oemol()], protein=cmplx.target.to_oemol()
+                )
+                viz_data.append(viz)
+                # write to disk
+                if self.write_to_disk:
+                    self.write_html(viz, outpath)
 
-            # make html string
-            viz = self.html_pose_viz(
-                poses=[cmplx.ligand.to_oemol()], protein=cmplx.target.to_oemol()
-            )
-            viz_data.append(viz)
-            # write to disk
-            if self.write_to_disk:
-                self.write_html(viz, outpath)
-
-            # make dataframe with ligand name, target name, and path to HTML
-            row = {}
-            row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
-            row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
-            row[DockingResultCols.SMILES.value] = cmplx.ligand.smiles
-            row[self.get_tag_for_color_method()] = outpath
-            data.append(row)
+                # make dataframe with ligand name, target name, and path to HTML
+                row = {}
+                row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
+                row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
+                row[DockingResultCols.SMILES.value] = cmplx.ligand.smiles
+                row[self.get_tag_for_color_method()] = outpath
+                data.append(row)
+            except Exception as e:
+                if error == "skip":
+                    logger.error(f"Error processing {cmplx.unique_name}: {e}")
+                elif error == "raise":
+                    raise e
+                else:
+                    raise ValueError(
+                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                    )
 
         if self.write_to_disk:
             # if we are writing to disk, return the metadata
@@ -317,6 +342,7 @@ class HTMLVisualizer(VisualizerBase):
         self,
         inputs: list[tuple[Complex, list[Ligand]]],
         outpaths: Optional[list[Path]] = None,
+        error: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
@@ -338,37 +364,47 @@ class HTMLVisualizer(VisualizerBase):
         data = []
         viz_data = []
         for i, inp in enumerate(inputs):
-            cmplx, liglist = inp
-            if self.write_to_disk:
-                if not outpaths:
-                    output_pref = cmplx.unique_name
-                    outpath = self.output_dir / output_pref / "pose.html"
+            try:
+                cmplx, liglist = inp
+                if self.write_to_disk:
+                    if not outpaths:
+                        output_pref = cmplx.unique_name
+                        outpath = self.output_dir / output_pref / "pose.html"
+                    else:
+                        outpath = self.output_dir / Path(outpaths[i])
+                    outpath.parent.mkdir(parents=True, exist_ok=True)
                 else:
-                    outpath = self.output_dir / Path(outpaths[i])
-                outpath.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                outpath = None
+                    outpath = None
 
-            # make html string
-            viz = self.html_pose_viz(
-                poses=[lig.to_oemol() for lig in liglist],
-                protein=cmplx.target.to_oemol(),
-            )
-            viz_data.append(viz)
-            # write to disk
-            if self.write_to_disk:
-                self.write_html(viz, outpath)
+                # make html string
+                viz = self.html_pose_viz(
+                    poses=[lig.to_oemol() for lig in liglist],
+                    protein=cmplx.target.to_oemol(),
+                )
+                viz_data.append(viz)
+                # write to disk
+                if self.write_to_disk:
+                    self.write_html(viz, outpath)
 
-            # make dataframe with ligand name, target name, and path to HTML
-            row = {}
-            row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
-            row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
-            if len(liglist) > 1:
-                row[DockingResultCols.SMILES.value] = "MANY"
-            else:
-                row[DockingResultCols.SMILES.value] = liglist[0].smiles
-            row[self.get_tag_for_color_method()] = outpath
-            data.append(row)
+                # make dataframe with ligand name, target name, and path to HTML
+                row = {}
+                row[DockingResultCols.LIGAND_ID.value] = cmplx.ligand.compound_name
+                row[DockingResultCols.TARGET_ID.value] = cmplx.target.target_name
+                if len(liglist) > 1:
+                    row[DockingResultCols.SMILES.value] = "MANY"
+                else:
+                    row[DockingResultCols.SMILES.value] = liglist[0].smiles
+                row[self.get_tag_for_color_method()] = outpath
+                data.append(row)
+            except Exception as e:
+                if error == "skip":
+                    logger.error(f"Error processing {cmplx.unique_name}: {e}")
+                elif error == "raise":
+                    raise e
+                else:
+                    raise ValueError(
+                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                    )
 
         if self.write_to_disk:
             # if we are writing to disk, return the metadata

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/html_viz.py
@@ -139,7 +139,7 @@ class HTMLVisualizer(VisualizerBase):
         elif self.color_method == "fitness":
             return make_color_res_fitness(protein, self.target)
 
-    @dask_vmap(["inputs"])
+    @dask_vmap(["inputs"], has_failure_mode=True)
     @backend_wrapper("inputs")
     def _visualize(
         self,
@@ -168,7 +168,7 @@ class HTMLVisualizer(VisualizerBase):
         self,
         inputs: list[DockingResult],
         outpaths: Optional[list[Path]] = None,
-        error: str = "skip",
+        failure_mode: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
@@ -221,13 +221,13 @@ class HTMLVisualizer(VisualizerBase):
                 row[self.get_tag_for_color_method()] = outpath
                 data.append(row)
             except Exception as e:
-                if error == "skip":
+                if failure_mode == "skip":
                     logger.error(f"Error processing {result.unique_name}: {e}")
-                elif error == "raise":
+                elif failure_mode == "raise":
                     raise e
                 else:
                     raise ValueError(
-                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
                     )
 
         if self.write_to_disk:
@@ -271,7 +271,7 @@ class HTMLVisualizer(VisualizerBase):
         self,
         inputs: list[Complex],
         outpaths: Optional[list[Path]] = None,
-        error: str = "skip",
+        failure_mode: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
@@ -321,13 +321,13 @@ class HTMLVisualizer(VisualizerBase):
                 row[self.get_tag_for_color_method()] = outpath
                 data.append(row)
             except Exception as e:
-                if error == "skip":
+                if failure_mode == "skip":
                     logger.error(f"Error processing {cmplx.unique_name}: {e}")
-                elif error == "raise":
+                elif failure_mode == "raise":
                     raise e
                 else:
                     raise ValueError(
-                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
                     )
 
         if self.write_to_disk:
@@ -342,7 +342,7 @@ class HTMLVisualizer(VisualizerBase):
         self,
         inputs: list[tuple[Complex, list[Ligand]]],
         outpaths: Optional[list[Path]] = None,
-        error: str = "skip",
+        failure_mode: str = "skip",
         **kwargs,
     ) -> Union[list[dict[str, str]], list[str]]:
         """
@@ -397,13 +397,13 @@ class HTMLVisualizer(VisualizerBase):
                 row[self.get_tag_for_color_method()] = outpath
                 data.append(row)
             except Exception as e:
-                if error == "skip":
+                if failure_mode == "skip":
                     logger.error(f"Error processing {cmplx.unique_name}: {e}")
-                elif error == "raise":
+                elif failure_mode == "raise":
                     raise e
                 else:
                     raise ValueError(
-                        f"Unknown error mode: {error}, must be 'skip' or 'raise'"
+                        f"Unknown error mode: {failure_mode}, must be 'skip' or 'raise'"
                     )
 
         if self.write_to_disk:

--- a/asapdiscovery-dataviz/asapdiscovery/dataviz/visualizer.py
+++ b/asapdiscovery-dataviz/asapdiscovery/dataviz/visualizer.py
@@ -1,7 +1,7 @@
 import abc
 
 import pandas as pd
-from asapdiscovery.data.util.dask_utils import BackendType, DaskFailureMode
+from asapdiscovery.data.util.dask_utils import BackendType, FailureMode
 from asapdiscovery.docking.docking import DockingResult
 from pydantic import BaseModel
 
@@ -19,7 +19,7 @@ class VisualizerBase(abc.ABC, BaseModel):
         inputs: list[DockingResult],
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         backend=BackendType.IN_MEMORY,
         reconstruct_cls=None,
         **kwargs,
@@ -28,7 +28,7 @@ class VisualizerBase(abc.ABC, BaseModel):
             inputs=inputs,
             use_dask=use_dask,
             dask_client=dask_client,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             backend=backend,
             reconstruct_cls=reconstruct_cls,
             **kwargs,

--- a/asapdiscovery-docking/asapdiscovery/docking/docking.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/docking.py
@@ -18,7 +18,7 @@ from asapdiscovery.data.schema.complex import PreppedComplex
 from asapdiscovery.data.schema.ligand import Ligand
 from asapdiscovery.data.schema.pairs import CompoundStructurePair
 from asapdiscovery.data.schema.sets import MultiStructureBase
-from asapdiscovery.data.util.dask_utils import BackendType, DaskFailureMode
+from asapdiscovery.data.util.dask_utils import BackendType, FailureMode
 from asapdiscovery.modeling.modeling import split_openeye_design_unit
 from pydantic import BaseModel, Field, PositiveFloat
 
@@ -90,7 +90,7 @@ class DockingBase(BaseModel):
         output_dir: Optional[Union[str, Path]] = None,
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         return_for_disk_backend: bool = False,
     ) -> list["DockingResult"]:
         """
@@ -107,8 +107,8 @@ class DockingBase(BaseModel):
             Whether to use dask, by default False
         dask_client : dask.distributed.Client, optional
             Dask client to use, by default None
-        dask_failure_mode : DaskFailureMode, optional
-            Dask failure mode, by default DaskFailureMode.SKIP
+        failure_mode : FailureMode, optional
+            Dask failure mode, by default FailureMode.SKIP
         return_for_disk_backend : bool, optional
             Whether to return the results for disk backend, by default False
 
@@ -126,7 +126,7 @@ class DockingBase(BaseModel):
             output_dir=output_dir,
             use_dask=use_dask,
             dask_client=dask_client,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             return_for_disk_backend=return_for_disk_backend,
         )
 

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -214,130 +214,130 @@ class POSITDocker(DockingBase):
         docking_results = []
 
         for set in inputs:
-            if output_dir is not None:
-                docked_result_json_path = Path(
-                    Path(output_dir) / set.unique_name / "docking_result.json"
-                )
+            try: 
+                if output_dir is not None:
+                    docked_result_json_path = Path(
+                        Path(output_dir) / set.unique_name / "docking_result.json"
+                    )
 
-            if (
-                set.is_cacheable
-                and (output_dir is not None)
-                and (docked_result_json_path.exists())
-            ):
-                logger.info(
-                    f"Docking result for {set.unique_name} already exists, reading from disk"
-                )
-                output_dir = Path(output_dir)
-                docking_results.append(
-                    POSITDockingResults.from_json_file(docked_result_json_path)
-                )
-            else:
-                dus = set.to_design_units()
-                lig_oemol = oechem.OEMol(set.ligand.to_oemol())
-                if self.use_omega:
-                    if self.omega_dense:
-                        omegaOpts = oeomega.OEOmegaOptions(
-                            oeomega.OEOmegaSampling_Dense
-                        )
-                    else:
-                        omegaOpts = oeomega.OEOmegaOptions()
-                    omega = oeomega.OEOmega(omegaOpts)
-                    omega_retcode = omega.Build(lig_oemol)
-                    if omega_retcode:
-                        error_msg = f"Omega failed with error code: {omega_retcode} : {oeomega.OEGetOmegaError(omega_retcode)}"
-                        if failure_mode == "skip":
-                            logger.error(error_msg)
-                        elif failure_mode == "raise":
-                            raise ValueError(error_msg)
-                        else:
-                            raise ValueError(f"Unknown error handling option {failure_mode}")
-
-                opts = oedocking.OEPositOptions()
-                opts.SetIgnoreNitrogenStereo(True)
-                opts.SetPositMethods(self.posit_method.value)
-                opts.SetPoseRelaxMode(self.relax.value)
-
-                pose_res = oedocking.OEPositResults()
-                pose_res, retcode = self.run_oe_posit_docking(
-                    opts, pose_res, dus, lig_oemol, self.num_poses
-                )
-
-                if self.allow_retries:
-                    # try again with no relaxation
-                    if retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses:
-                        opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_NONE)
-                        pose_res, retcode = self.run_oe_posit_docking(
-                            opts, pose_res, dus, lig_oemol, self.num_poses
-                        )
-
-                    # try again with low posit probability
-                    if (
-                        retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses
-                        and self.allow_low_posit_prob
-                    ):
-                        opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_ALL)
-                        opts.SetMinProbability(self.low_posit_prob_thresh)
-                        pose_res, retcode = self.run_oe_posit_docking(
-                            opts, pose_res, dus, lig_oemol, self.num_poses
-                        )
-
-                    # try again allowing clashes
-                    if (
-                        self.allow_final_clash
-                        and retcode
-                        == oedocking.OEDockingReturnCode_NoValidNonClashPoses
-                    ):
-                        opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_ALL)
-                        opts.SetAllowedClashType(oedocking.OEAllowedClashType_ANY)
-                        pose_res, retcode = self.run_oe_posit_docking(
-                            opts, pose_res, dus, lig_oemol, self.num_poses
-                        )
-
-                if retcode == oedocking.OEDockingReturnCode_Success:
-                    for result in pose_res.GetSinglePoseResults():
-                        posed_mol = result.GetPose()
-                        prob = result.GetProbability()
-
-                        posed_ligand = Ligand.from_oemol(posed_mol, **set.ligand.dict())
-                        # set SD tags
-                        sd_data = {
-                            DockingResultCols.DOCKING_CONFIDENCE_POSIT.value: prob,
-                            DockingResultCols.POSIT_METHOD.value: oedocking.OEPositMethodGetName(
-                                result.GetPositMethod()
-                            ),
-                        }
-                        posed_ligand.set_SD_data(sd_data)
-
-                        # Generate info about which target was actually used by multi-reference docking
-                        if isinstance(set, DockingInputMultiStructure):
-                            docked_target = set.complexes[result.GetReceptorIndex()]
-                            input_pair = DockingInputPair(
-                                ligand=set.ligand, complex=docked_target
+                if (
+                    set.is_cacheable
+                    and (output_dir is not None)
+                    and (docked_result_json_path.exists())
+                ):
+                    logger.info(
+                        f"Docking result for {set.unique_name} already exists, reading from disk"
+                    )
+                    output_dir = Path(output_dir)
+                    docking_results.append(
+                        POSITDockingResults.from_json_file(docked_result_json_path)
+                    )
+                else:
+                    dus = set.to_design_units()
+                    lig_oemol = oechem.OEMol(set.ligand.to_oemol())
+                    if self.use_omega:
+                        if self.omega_dense:
+                            omegaOpts = oeomega.OEOmegaOptions(
+                                oeomega.OEOmegaSampling_Dense
                             )
                         else:
-                            input_pair = set
+                            omegaOpts = oeomega.OEOmegaOptions()
+                        omega = oeomega.OEOmega(omegaOpts)
+                        omega_retcode = omega.Build(lig_oemol)
+                        if omega_retcode:
+                            error_msg = f"Omega failed with error code: {omega_retcode} : {oeomega.OEGetOmegaError(omega_retcode)}"
+                            if failure_mode == "skip":
+                                logger.error(error_msg)
+                            elif failure_mode == "raise":
+                                raise ValueError(error_msg)
+                            else:
+                                raise ValueError(f"Unknown error handling option {failure_mode}")
 
-                        docking_result = POSITDockingResults(
-                            input_pair=input_pair,
-                            posed_ligand=posed_ligand,
-                            probability=prob,
-                            provenance=self.provenance(),
-                        )
-                        if return_for_disk_backend:
-                            docking_results.append(docked_result_json_path)
-                        else:
-                            docking_results.append(docking_result)
-                        if output_dir is not None:
-                            docking_result.write_docking_files(output_dir)
+                    opts = oedocking.OEPositOptions()
+                    opts.SetIgnoreNitrogenStereo(True)
+                    opts.SetPositMethods(self.posit_method.value)
+                    opts.SetPoseRelaxMode(self.relax.value)
 
+                    pose_res = oedocking.OEPositResults()
+                    pose_res, retcode = self.run_oe_posit_docking(
+                        opts, pose_res, dus, lig_oemol, self.num_poses
+                    )
+
+                    if self.allow_retries:
+                        # try again with no relaxation
+                        if retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses:
+                            opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_NONE)
+                            pose_res, retcode = self.run_oe_posit_docking(
+                                opts, pose_res, dus, lig_oemol, self.num_poses
+                            )
+
+                        # try again with low posit probability
+                        if (
+                            retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses
+                            and self.allow_low_posit_prob
+                        ):
+                            opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_ALL)
+                            opts.SetMinProbability(self.low_posit_prob_thresh)
+                            pose_res, retcode = self.run_oe_posit_docking(
+                                opts, pose_res, dus, lig_oemol, self.num_poses
+                            )
+
+                        # try again allowing clashes
+                        if (
+                            self.allow_final_clash
+                            and retcode
+                            == oedocking.OEDockingReturnCode_NoValidNonClashPoses
+                        ):
+                            opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_ALL)
+                            opts.SetAllowedClashType(oedocking.OEAllowedClashType_ANY)
+                            pose_res, retcode = self.run_oe_posit_docking(
+                                opts, pose_res, dus, lig_oemol, self.num_poses
+                            )
+
+                    if retcode == oedocking.OEDockingReturnCode_Success:
+                        for result in pose_res.GetSinglePoseResults():
+                            posed_mol = result.GetPose()
+                            prob = result.GetProbability()
+
+                            posed_ligand = Ligand.from_oemol(posed_mol, **set.ligand.dict())
+                            # set SD tags
+                            sd_data = {
+                                DockingResultCols.DOCKING_CONFIDENCE_POSIT.value: prob,
+                                DockingResultCols.POSIT_METHOD.value: oedocking.OEPositMethodGetName(
+                                    result.GetPositMethod()
+                                ),
+                            }
+                            posed_ligand.set_SD_data(sd_data)
+
+                            # Generate info about which target was actually used by multi-reference docking
+                            if isinstance(set, DockingInputMultiStructure):
+                                docked_target = set.complexes[result.GetReceptorIndex()]
+                                input_pair = DockingInputPair(
+                                    ligand=set.ligand, complex=docked_target
+                                )
+                            else:
+                                input_pair = set
+
+                            docking_result = POSITDockingResults(
+                                input_pair=input_pair,
+                                posed_ligand=posed_ligand,
+                                probability=prob,
+                                provenance=self.provenance(),
+                            )
+                            if return_for_disk_backend:
+                                docking_results.append(docked_result_json_path)
+                            else:
+                                docking_results.append(docking_result)
+                            if output_dir is not None:
+                                docking_result.write_docking_files(output_dir)
+            except Exception as e:
+                error_msg = f"docking failed for input pair with compound name: {set.ligand.compound_name}, smiles: {set.ligand.smiles} and target name: {set.complex.target.target_name} with error: {e}"
+                if failure_mode == "skip":
+                    logger.error(error_msg)
+                elif failure_mode == "raise":
+                    raise ValueError(error_msg)
                 else:
-                    error_msg = f"docking failed for input pair with compound name: {set.ligand.compound_name}, smiles: {set.ligand.smiles} and target name: {set.complex.target.target_name}"
-                    if failure_mode == "skip":
-                        logger.warn(error_msg)
-                    elif failure_mode == "raise":
-                        raise ValueError(error_msg)
-                    else:
-                        raise ValueError(f"Unknown error handling option {error}")
+                    raise ValueError(f"Unknown error handling option {failure_mode}")
 
         return docking_results
 

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -189,7 +189,7 @@ class POSITDocker(DockingBase):
         retcode = poser.Dock(pose_res, lig, num_poses)
         return pose_res, retcode
 
-    @dask_vmap(["inputs"])
+    @dask_vmap(["inputs"], has_failure_mode=True)
     def _dock(
         self,
         inputs: list[
@@ -199,8 +199,9 @@ class POSITDocker(DockingBase):
             ]
         ],
         output_dir: Optional[Union[str, Path]] = None,
-        error="skip",
+        failure_mode="skip",
         return_for_disk_backend=False,
+        **kwargs,
     ) -> list[DockingResult]:
         """
         Docking workflow using OEPosit
@@ -331,9 +332,9 @@ class POSITDocker(DockingBase):
 
                 else:
                     error_msg = f"docking failed for input pair with compound name: {set.ligand.compound_name}, smiles: {set.ligand.smiles} and target name: {set.complex.target.target_name}"
-                    if error == "skip":
+                    if failure_mode == "skip":
                         logger.warn(error_msg)
-                    elif error == "raise":
+                    elif failure_mode == "raise":
                         raise ValueError(error_msg)
                     else:
                         raise ValueError(f"Unknown error handling option {error}")

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -77,21 +77,21 @@ class POSITDockingResults(DockingResult):
         df_prep = []
         for result in results:
             docking_dict = {}
-            docking_dict[DockingResultCols.LIGAND_ID.value] = (
-                result.input_pair.ligand.compound_name
-            )
-            docking_dict[DockingResultCols.TARGET_ID.value] = (
-                result.input_pair.complex.target.target_name
-            )
-            docking_dict["target_bound_compound_smiles"] = (
-                result.input_pair.complex.ligand.smiles
-            )
-            docking_dict[DockingResultCols.SMILES.value] = (
-                result.input_pair.ligand.smiles
-            )
-            docking_dict[DockingResultCols.DOCKING_CONFIDENCE_POSIT.value] = (
-                result.probability
-            )
+            docking_dict[
+                DockingResultCols.LIGAND_ID.value
+            ] = result.input_pair.ligand.compound_name
+            docking_dict[
+                DockingResultCols.TARGET_ID.value
+            ] = result.input_pair.complex.target.target_name
+            docking_dict[
+                "target_bound_compound_smiles"
+            ] = result.input_pair.complex.ligand.smiles
+            docking_dict[
+                DockingResultCols.SMILES.value
+            ] = result.input_pair.ligand.smiles
+            docking_dict[
+                DockingResultCols.DOCKING_CONFIDENCE_POSIT.value
+            ] = result.probability
             df_prep.append(docking_dict)
 
         df = pd.DataFrame(df_prep)
@@ -333,7 +333,6 @@ class POSITDocker(DockingBase):
                     error_msg = f"docking failed for input pair with compound name: {set.ligand.compound_name}, smiles: {set.ligand.smiles} and target name: {set.complex.target.target_name}"
                     if error == "skip":
                         logger.warn(error_msg)
-                        docking_results.append(None)
                     elif error == "raise":
                         raise ValueError(error_msg)
                     else:

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -77,21 +77,21 @@ class POSITDockingResults(DockingResult):
         df_prep = []
         for result in results:
             docking_dict = {}
-            docking_dict[
-                DockingResultCols.LIGAND_ID.value
-            ] = result.input_pair.ligand.compound_name
-            docking_dict[
-                DockingResultCols.TARGET_ID.value
-            ] = result.input_pair.complex.target.target_name
-            docking_dict[
-                "target_bound_compound_smiles"
-            ] = result.input_pair.complex.ligand.smiles
-            docking_dict[
-                DockingResultCols.SMILES.value
-            ] = result.input_pair.ligand.smiles
-            docking_dict[
-                DockingResultCols.DOCKING_CONFIDENCE_POSIT.value
-            ] = result.probability
+            docking_dict[DockingResultCols.LIGAND_ID.value] = (
+                result.input_pair.ligand.compound_name
+            )
+            docking_dict[DockingResultCols.TARGET_ID.value] = (
+                result.input_pair.complex.target.target_name
+            )
+            docking_dict["target_bound_compound_smiles"] = (
+                result.input_pair.complex.ligand.smiles
+            )
+            docking_dict[DockingResultCols.SMILES.value] = (
+                result.input_pair.ligand.smiles
+            )
+            docking_dict[DockingResultCols.DOCKING_CONFIDENCE_POSIT.value] = (
+                result.probability
+            )
             df_prep.append(docking_dict)
 
         df = pd.DataFrame(df_prep)

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -245,12 +245,12 @@ class POSITDocker(DockingBase):
                     omega_retcode = omega.Build(lig_oemol)
                     if omega_retcode:
                         error_msg = f"Omega failed with error code: {omega_retcode} : {oeomega.OEGetOmegaError(omega_retcode)}"
-                        if error == "skip":
+                        if failure_mode == "skip":
                             logger.error(error_msg)
-                        elif error == "raise":
+                        elif failure_mode == "raise":
                             raise ValueError(error_msg)
                         else:
-                            raise ValueError(f"Unknown error handling option {error}")
+                            raise ValueError(f"Unknown error handling option {failure_mode}")
 
                 opts = oedocking.OEPositOptions()
                 opts.SetIgnoreNitrogenStereo(True)

--- a/asapdiscovery-docking/asapdiscovery/docking/openeye.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/openeye.py
@@ -214,7 +214,7 @@ class POSITDocker(DockingBase):
         docking_results = []
 
         for set in inputs:
-            try: 
+            try:
                 if output_dir is not None:
                     docked_result_json_path = Path(
                         Path(output_dir) / set.unique_name / "docking_result.json"
@@ -251,7 +251,9 @@ class POSITDocker(DockingBase):
                             elif failure_mode == "raise":
                                 raise ValueError(error_msg)
                             else:
-                                raise ValueError(f"Unknown error handling option {failure_mode}")
+                                raise ValueError(
+                                    f"Unknown error handling option {failure_mode}"
+                                )
 
                     opts = oedocking.OEPositOptions()
                     opts.SetIgnoreNitrogenStereo(True)
@@ -265,7 +267,10 @@ class POSITDocker(DockingBase):
 
                     if self.allow_retries:
                         # try again with no relaxation
-                        if retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses:
+                        if (
+                            retcode
+                            == oedocking.OEDockingReturnCode_NoValidNonClashPoses
+                        ):
                             opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_NONE)
                             pose_res, retcode = self.run_oe_posit_docking(
                                 opts, pose_res, dus, lig_oemol, self.num_poses
@@ -273,7 +278,8 @@ class POSITDocker(DockingBase):
 
                         # try again with low posit probability
                         if (
-                            retcode == oedocking.OEDockingReturnCode_NoValidNonClashPoses
+                            retcode
+                            == oedocking.OEDockingReturnCode_NoValidNonClashPoses
                             and self.allow_low_posit_prob
                         ):
                             opts.SetPoseRelaxMode(oedocking.OEPoseRelaxMode_ALL)
@@ -299,7 +305,9 @@ class POSITDocker(DockingBase):
                             posed_mol = result.GetPose()
                             prob = result.GetProbability()
 
-                            posed_ligand = Ligand.from_oemol(posed_mol, **set.ligand.dict())
+                            posed_ligand = Ligand.from_oemol(
+                                posed_mol, **set.ligand.dict()
+                            )
                             # set SD tags
                             sd_data = {
                                 DockingResultCols.DOCKING_CONFIDENCE_POSIT.value: prob,

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer.py
@@ -218,8 +218,7 @@ class ScorerBase(BaseModel):
     score_units: ClassVar[ScoreUnits.INVALID] = ScoreUnits.INVALID
 
     @abc.abstractmethod
-    def _score() -> list[DockingResult]:
-        ...
+    def _score() -> list[DockingResult]: ...
 
     def score(
         self,

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer.py
@@ -218,7 +218,8 @@ class ScorerBase(BaseModel):
     score_units: ClassVar[ScoreUnits.INVALID] = ScoreUnits.INVALID
 
     @abc.abstractmethod
-    def _score() -> list[DockingResult]: ...
+    def _score() -> list[DockingResult]:
+        ...
 
     def score(
         self,
@@ -289,7 +290,6 @@ class ScorerBase(BaseModel):
         data_list = []
         # flatten the list of scores
         scores = np.ravel(scores)
-
         for score in scores:
             dct = score.dict()
             dct["score_type"] = score.score_type.value  # convert to string

--- a/asapdiscovery-docking/asapdiscovery/docking/scorer.py
+++ b/asapdiscovery-docking/asapdiscovery/docking/scorer.py
@@ -14,7 +14,7 @@ from asapdiscovery.data.schema.target import TargetIdentifiers
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
 from asapdiscovery.data.util.dask_utils import (
     BackendType,
-    DaskFailureMode,
+    FailureMode,
     backend_wrapper,
     dask_vmap,
 )
@@ -227,7 +227,7 @@ class ScorerBase(BaseModel):
         ],
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         backend=BackendType.IN_MEMORY,
         reconstruct_cls=None,
         return_df: bool = False,
@@ -245,8 +245,8 @@ class ScorerBase(BaseModel):
             Whether to use dask, by default False
         dask_client : dask.distributed.Client, optional
             Dask client to use, by default None
-        dask_failure_mode : DaskFailureMode, optional
-            How to handle dask failures, by default DaskFailureMode.SKIP
+        failure_mode : FailureMode, optional
+            How to handle dask failures, by default FailureMode.SKIP
         backend : BackendType, optional
             Backend to use, by default BackendType.IN_MEMORY
         reconstruct_cls : Optional[Callable], optional
@@ -260,7 +260,7 @@ class ScorerBase(BaseModel):
             inputs=inputs,
             use_dask=use_dask,
             dask_client=dask_client,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             backend=backend,
             reconstruct_cls=reconstruct_cls,
         )
@@ -702,7 +702,7 @@ class MetaScorer(BaseModel):
         inputs: list[DockingResult],
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         backend=BackendType.IN_MEMORY,
         reconstruct_cls=None,
         return_df: bool = False,
@@ -717,7 +717,7 @@ class MetaScorer(BaseModel):
                 inputs=inputs,
                 use_dask=use_dask,
                 dask_client=dask_client,
-                dask_failure_mode=dask_failure_mode,
+                failure_mode=failure_mode,
                 backend=backend,
                 reconstruct_cls=reconstruct_cls,
                 return_df=return_df,

--- a/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
+++ b/asapdiscovery-modeling/asapdiscovery/modeling/protein_prep.py
@@ -52,8 +52,7 @@ class ProteinPrepperBase(BaseModel):
         arbitrary_types_allowed = True
 
     @abc.abstractmethod
-    def _prep(self, inputs: list[Complex]) -> list[PreppedComplex]:
-        ...
+    def _prep(self, inputs: list[Complex]) -> list[PreppedComplex]: ...
 
     @staticmethod
     def _gather_new_tasks(
@@ -167,8 +166,7 @@ class ProteinPrepperBase(BaseModel):
         return all_outputs
 
     @abc.abstractmethod
-    def provenance(self) -> dict[str, str]:
-        ...
+    def provenance(self) -> dict[str, str]: ...
 
     @staticmethod
     def cache(

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -10,7 +10,7 @@ import openmm
 import pandas as pd
 from asapdiscovery.data.backend.openeye import save_openeye_pdb
 from asapdiscovery.data.util.dask_utils import (
-    DaskFailureMode,
+    FailureMode,
     actualise_dask_delayed_iterable,
 )
 from asapdiscovery.data.util.stringenum import StringEnum
@@ -84,7 +84,7 @@ class SimulatorBase(BaseModel):
         docking_results: list[DockingResult],
         use_dask: bool = False,
         dask_client=None,
-        dask_failure_mode=DaskFailureMode.SKIP,
+        failure_mode=FailureMode.SKIP,
         **kwargs,
     ) -> pd.DataFrame:
         if use_dask:
@@ -93,7 +93,7 @@ class SimulatorBase(BaseModel):
                 out = dask.delayed(self._simulate)(docking_results=[res], **kwargs)
                 delayed_outputs.append(out)
             outputs = actualise_dask_delayed_iterable(
-                delayed_outputs, dask_client, errors=dask_failure_mode
+                delayed_outputs, dask_client, errors=failure_mode
             )
             outputs = [item for sublist in outputs for item in sublist]  # flatten
         else:

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cli.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cli.py
@@ -23,7 +23,7 @@ from asapdiscovery.cli.cli_args import (
 )
 from asapdiscovery.data.operators.selectors.selector_list import StructureSelector
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import DaskType, FailureMode
 from asapdiscovery.simulation.simulate import OpenMMPlatform
 from asapdiscovery.workflows.docking_workflows.cross_docking import (
     CrossDockingWorkflowInputs,

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cli.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cli.py
@@ -23,7 +23,7 @@ from asapdiscovery.cli.cli_args import (
 )
 from asapdiscovery.data.operators.selectors.selector_list import StructureSelector
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import DaskFailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
 from asapdiscovery.simulation.simulate import OpenMMPlatform
 from asapdiscovery.workflows.docking_workflows.cross_docking import (
     CrossDockingWorkflowInputs,
@@ -112,7 +112,7 @@ def large_scale(
     input_json: Optional[str] = None,
     use_dask: bool = False,
     dask_type: DaskType = DaskType.LOCAL,
-    dask_failure_mode: DaskFailureMode = DaskFailureMode.SKIP,
+    failure_mode: FailureMode = FailureMode.SKIP,
     ml_scorer: Optional[list[str]] = None,
     loglevel: Union[int, str] = logging.INFO,
     walltime: Optional[str] = "72h",
@@ -134,7 +134,7 @@ def large_scale(
             top_n=top_n,
             use_dask=use_dask,
             dask_type=dask_type,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             posit_confidence_cutoff=posit_confidence_cutoff,
             use_omega=use_omega,
             allow_posit_retries=allow_posit_retries,
@@ -228,7 +228,7 @@ def cross_docking(
     input_json: Optional[str] = None,
     use_dask: bool = False,
     dask_type: DaskType = DaskType.LOCAL,
-    dask_failure_mode: DaskFailureMode = DaskFailureMode.SKIP,
+    failure_mode: FailureMode = FailureMode.SKIP,
     loglevel: Union[int, str] = logging.INFO,
     walltime: Optional[str] = "72h",
 ):
@@ -247,7 +247,7 @@ def cross_docking(
             structure_selector=structure_selector,
             use_dask=use_dask,
             dask_type=dask_type,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             use_omega=use_omega,
             omega_dense=omega_dense,
             num_poses=num_poses,
@@ -325,7 +325,7 @@ def small_scale(
     input_json: Optional[str] = None,
     use_dask: bool = False,
     dask_type: DaskType = DaskType.LOCAL,
-    dask_failure_mode: DaskFailureMode = DaskFailureMode.SKIP,
+    failure_mode: FailureMode = FailureMode.SKIP,
     ml_scorer: Optional[list[str]] = None,
     md: bool = False,
     md_steps: int = 2500000,  # 10 ns @ 4.0 fs timestep
@@ -348,7 +348,7 @@ def small_scale(
             target=target,
             use_dask=use_dask,
             dask_type=dask_type,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             posit_confidence_cutoff=posit_confidence_cutoff,
             n_select=n_select,
             allow_dask_cuda=allow_dask_cuda,

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cross_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/cross_docking.py
@@ -133,7 +133,7 @@ def cross_docking_workflow(inputs: CrossDockingWorkflowInputs):
         fragalysis_dir=inputs.fragalysis_dir,
         pdb_file=inputs.pdb_file,
         use_dask=inputs.use_dask,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         dask_client=dask_client,
     )
     complexes = structure_factory.load()
@@ -150,7 +150,7 @@ def cross_docking_workflow(inputs: CrossDockingWorkflowInputs):
         complexes,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         cache_dir=inputs.cache_dir,
         use_only_cache=inputs.use_only_cache,
     )
@@ -205,7 +205,7 @@ def cross_docking_workflow(inputs: CrossDockingWorkflowInputs):
         output_dir=output_dir / "docking_results",
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
     )
 
     n_results = len(results)
@@ -232,7 +232,7 @@ def cross_docking_workflow(inputs: CrossDockingWorkflowInputs):
         use_dask=inputs.use_dask,
         dask_client=dask_client,
         return_df=True,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
     )
 
     del results

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
@@ -380,9 +380,9 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         )
 
         # duplicate target id column so we can join
-        fitness_visualizations[DockingResultCols.DOCKING_STRUCTURE_POSIT.value] = (
-            fitness_visualizations[DockingResultCols.TARGET_ID.value]
-        )
+        fitness_visualizations[
+            DockingResultCols.DOCKING_STRUCTURE_POSIT.value
+        ] = fitness_visualizations[DockingResultCols.TARGET_ID.value]
 
         # join the two dataframes on ligand_id, target_id and smiles
         scores_df = scores_df.merge(

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
@@ -191,7 +191,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
     )
     complexes = structure_factory.load(
         use_dask=inputs.use_dask,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         dask_client=dask_client,
     )
 
@@ -230,7 +230,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         complexes,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         cache_dir=inputs.cache_dir,
     )
     del complexes
@@ -269,7 +269,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         output_dir=output_dir / "docking_results",
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         return_for_disk_backend=True,
     )
 
@@ -318,7 +318,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         results,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         return_df=True,
         backend=BackendType.DISK,
         reconstruct_cls=docker.result_cls,
@@ -338,7 +338,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         results,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         backend=BackendType.DISK,
         reconstruct_cls=docker.result_cls,
     )
@@ -374,7 +374,7 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
             results,
             use_dask=inputs.use_dask,
             dask_client=dask_client,
-            dask_failure_mode=inputs.dask_failure_mode,
+            failure_mode=inputs.failure_mode,
             backend=BackendType.DISK,
             reconstruct_cls=docker.result_cls,
         )

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/large_scale_docking.py
@@ -380,9 +380,9 @@ def large_scale_docking_workflow(inputs: LargeScaleDockingInputs):
         )
 
         # duplicate target id column so we can join
-        fitness_visualizations[
-            DockingResultCols.DOCKING_STRUCTURE_POSIT.value
-        ] = fitness_visualizations[DockingResultCols.TARGET_ID.value]
+        fitness_visualizations[DockingResultCols.DOCKING_STRUCTURE_POSIT.value] = (
+            fitness_visualizations[DockingResultCols.TARGET_ID.value]
+        )
 
         # join the two dataframes on ligand_id, target_id and smiles
         scores_df = scores_df.merge(

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/small_scale_docking.py
@@ -222,12 +222,12 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
         fragalysis_dir=inputs.fragalysis_dir,
         pdb_file=inputs.pdb_file,
         use_dask=inputs.use_dask,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         dask_client=dask_client,
     )
     complexes = structure_factory.load(
         use_dask=inputs.use_dask,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         dask_client=dask_client,
     )
 
@@ -261,7 +261,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
         cache_dir=inputs.cache_dir,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
     )
     del complexes
 
@@ -296,7 +296,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
         output_dir=output_dir / "docking_results",
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
     )
 
     n_results = len(results)
@@ -333,7 +333,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
         results,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
         return_df=True,
         include_input=True,
     )
@@ -371,7 +371,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
         results,
         use_dask=inputs.use_dask,
         dask_client=dask_client,
-        dask_failure_mode=inputs.dask_failure_mode,
+        failure_mode=inputs.failure_mode,
     )
     # rename visualisations target id column to POSIT structure tag so we can join
     pose_visualizatons.rename(
@@ -404,7 +404,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
             results,
             use_dask=inputs.use_dask,
             dask_client=dask_client,
-            dask_failure_mode=inputs.dask_failure_mode,
+            failure_mode=inputs.failure_mode,
         )
 
         # duplicate target id column so we can join
@@ -502,7 +502,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
             results,
             use_dask=inputs.use_dask,
             dask_client=dask_client,
-            dask_failure_mode=inputs.dask_failure_mode,
+            failure_mode=inputs.failure_mode,
         )
 
         if local_cpu_client_gpu_override and inputs.use_dask:
@@ -524,7 +524,7 @@ def small_scale_docking_workflow(inputs: SmallScaleDockingInputs):
             simulation_results,
             use_dask=inputs.use_dask,
             dask_client=dask_client,
-            dask_failure_mode=inputs.dask_failure_mode,
+            failure_mode=inputs.failure_mode,
         )
         gifs.to_csv(data_intermediates / "md_gifs.csv", index=False)
         # duplicate target id column so we can join

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/workflows.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/workflows.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import DaskFailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
 from pydantic import BaseModel, Field, PositiveInt, root_validator
 
 
@@ -54,8 +54,8 @@ class DockingWorkflowInputsBase(BaseModel):
         DaskType.LOCAL, description="Dask client to use for parallelism."
     )
 
-    dask_failure_mode: DaskFailureMode = Field(
-        DaskFailureMode.SKIP, description="Dask failure mode."
+    failure_mode: FailureMode = Field(
+        FailureMode.SKIP, description="Dask failure mode."
     )
 
     dask_cluster_n_workers: PositiveInt = Field(

--- a/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/workflows.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/docking_workflows/workflows.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
-from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import DaskType, FailureMode
 from pydantic import BaseModel, Field, PositiveInt, root_validator
 
 

--- a/asapdiscovery-workflows/asapdiscovery/workflows/prep_workflows/cli.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/prep_workflows/cli.py
@@ -11,7 +11,7 @@ from asapdiscovery.cli.cli_args import (
     structure_dir,
     target,
 )
-from asapdiscovery.data.util.dask_utils import DaskFailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
 
 if TYPE_CHECKING:
     from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags
@@ -83,7 +83,7 @@ def protein_prep(
     save_to_cache: bool = True,
     use_dask: bool = False,
     dask_type: DaskType = DaskType.LOCAL,
-    dask_failure_mode: DaskFailureMode = DaskFailureMode.SKIP,
+    failure_mode: FailureMode = FailureMode.SKIP,
     output_dir: str = "output",
     input_json: Optional[str] = None,
 ):
@@ -115,7 +115,7 @@ def protein_prep(
             save_to_cache=save_to_cache,
             use_dask=use_dask,
             dask_type=dask_type,
-            dask_failure_mode=dask_failure_mode,
+            failure_mode=failure_mode,
             output_dir=output_dir,
         )
 

--- a/asapdiscovery-workflows/asapdiscovery/workflows/prep_workflows/cli.py
+++ b/asapdiscovery-workflows/asapdiscovery/workflows/prep_workflows/cli.py
@@ -11,7 +11,7 @@ from asapdiscovery.cli.cli_args import (
     structure_dir,
     target,
 )
-from asapdiscovery.data.util.dask_utils import FailureMode, DaskType
+from asapdiscovery.data.util.dask_utils import DaskType, FailureMode
 
 if TYPE_CHECKING:
     from asapdiscovery.data.services.postera.manifold_data_validation import TargetTags


### PR DESCRIPTION
FIxes #1017 

Needs some wrangling around the `failure-mode` argument, but also fixes a few issues, including incorporating the changed in #997 (tagging @apayne97 ) which had a subtle interaction with the way dask backend handled array shaping, leading to #989 

## Developers certificate of origin
- [X] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
