### PR TITLE
Add MAFFT to the yaml installers

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/models.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/models.py
@@ -218,8 +218,8 @@ class MLModelRegistry(BaseModel):
                 f"Target {target} not valid, must be one of {TargetTags.get_values()}"
             )
         return [model for model in self.models.values() if target in model.targets]
-    
-    def get_targets_with_models(self) -> List[TargetTags]:
+
+    def get_targets_with_models(self) -> list[TargetTags]:
         """
         Get all targets with models
 
@@ -228,7 +228,9 @@ class MLModelRegistry(BaseModel):
         List[TargetTags]
             List of targets with models
         """
-        return list({target.value for model in self.models.values() for target in model.targets})
+        return list(
+            {target.value for model in self.models.values() for target in model.targets}
+        )
 
     def get_latest_model_for_target_and_type(
         self, target: TargetTags, type: ModelType

--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -34,6 +34,7 @@ dependencies:
   - panel
   - plotmol
   - semver
+  - mafft
 
   # data
   - requests

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -34,6 +34,7 @@ dependencies:
   - panel
   - plotmol
   - semver
+  - mafft
 
   # data
   - requests


### PR DESCRIPTION
## Description
I want to add MAFFT, the multi-sequence alignment tool I use for the genetics pipeline, to the .yml files since it can be installed via conda-forge now. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Add MAFFT line to yml
- [ ] Fix test errors 

## Questions
- [ ] Question 1 ..

## Status
- [ ] Ready to go


## Developers certificate of origin
- [ ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
