### PR TITLE
`ASAP-Simulate`: update small molecule FF in `VanillaMDSimulator`

### DIFF
--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -164,6 +164,11 @@ class VanillaMDSimulator(SimulatorBase):
         description="Whether to truncate num_steps to multiple of reporting interval, used mostly for testing",
     )
 
+    small_molecule_force_field: str = Field(
+        "openff-2.2.0.offxml",
+        description="The name off the OpenFF small molecule force field which should be used for the ligand."
+    )
+
     @validator("rmsd_restraint_type")
     @classmethod
     def check_restraint_type(cls, v):
@@ -324,8 +329,7 @@ class VanillaMDSimulator(SimulatorBase):
         ligand_mol = Molecule(rdkitmolh)
         return ligand_mol
 
-    @staticmethod
-    def create_system_generator(ligand_mol):
+    def create_system_generator(self, ligand_mol):
         forcefield_kwargs = {
             "constraints": app.HBonds,
             "rigidWater": True,
@@ -335,7 +339,7 @@ class VanillaMDSimulator(SimulatorBase):
         periodic_forcefield_kwargs = {"nonbondedMethod": app.PME}
         system_generator = SystemGenerator(
             forcefields=["amber/ff14SB.xml", "amber/tip3p_standard.xml"],
-            small_molecule_forcefield="openff-1.3.1",
+            small_molecule_forcefield=self.small_molecule_force_field,
             molecules=[ligand_mol],
             cache=None,
             forcefield_kwargs=forcefield_kwargs,

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -166,7 +166,7 @@ class VanillaMDSimulator(SimulatorBase):
 
     small_molecule_force_field: str = Field(
         "openff-2.2.0.offxml",
-        description="The name off the OpenFF small molecule force field which should be used for the ligand.",
+        description="The OpenFF small molecule force field which should be used for the ligand.",
     )
 
     @validator("rmsd_restraint_type")

--- a/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
+++ b/asapdiscovery-simulation/asapdiscovery/simulation/simulate.py
@@ -166,7 +166,7 @@ class VanillaMDSimulator(SimulatorBase):
 
     small_molecule_force_field: str = Field(
         "openff-2.2.0.offxml",
-        description="The name off the OpenFF small molecule force field which should be used for the ligand."
+        description="The name off the OpenFF small molecule force field which should be used for the ligand.",
     )
 
     @validator("rmsd_restraint_type")

--- a/devtools/conda-envs/asapdiscovery-macOS-12.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-12.yml
@@ -24,6 +24,7 @@ dependencies:
   - appdirs
   - mdanalysis
   - openff-toolkit
+  - openff-forcefields >=2024.04.0
   - openeye-toolkits <2023.2.3
   - pandas
   - pebble

--- a/devtools/conda-envs/asapdiscovery-macOS-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-macOS-latest.yml
@@ -24,6 +24,7 @@ dependencies:
   - appdirs
   - mdanalysis
   - openff-toolkit
+  - openff-forcefields >=2024.04.0
   - openeye-toolkits <2023.2.3
   - pandas
   - pebble

--- a/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
+++ b/devtools/conda-envs/asapdiscovery-ubuntu-latest.yml
@@ -24,6 +24,7 @@ dependencies:
   - appdirs
   - mdanalysis
   - openff-toolkit
+  - openff-forcefields >=2024.04.0
   - openeye-toolkits <2023.2.3
   - pandas
   - pebble


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

This PR exposed the small molecule OpenFF force field used in the `VanillaMDSimulator` as an option and updates the default to `openff-2.2.0.offxml` to take advantage of the improved sulfamide modelled geometries! 

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] update the default small molecule force field
- [x] expose setting the force field as an option in the schema

## Questions
- [ ] Should we also expose the protein force field? 

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
