### PR TITLE
Remove cudatoolkit dep from macos simulation env

### DIFF
--- a/devtools/conda-envs/macos-latest/simulation.yaml
+++ b/devtools/conda-envs/macos-latest/simulation.yaml
@@ -43,7 +43,6 @@ dependencies:
   - openmmtools
   - openmmforcefields >= 0.13.0
   - mdtraj
-  - cudatoolkit
   - gufe >=1.0.0
   - pymol-open-source
   - rdkit


### PR DESCRIPTION
## Description
It's in the name. In theory now the CI for simulation for macos should pass.

## Status
- [x] make sure simulation workflow for macos and ubuntu pass
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
