### PR TITLE
Add option to randomly shuffle dataset

### DIFF
--- a/asapdiscovery-ml/asapdiscovery/ml/cli.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/cli.py
@@ -73,6 +73,7 @@ def build_ds(
     e3nn_dataset: bool | None = None,
     ds_cache: Path | None = None,
     ds_config_cache: Path | None = None,
+    ds_random_iter: bool | None = None,
     exp_file: Path | None = None,
     structures: str | None = None,
     xtal_regex: str = MPRO_ID_REGEX,
@@ -108,6 +109,7 @@ def build_ds(
         "overwrite": overwrite_ds_cache,
         "export_input_data": export_input_data,
         "export_exp_data": export_exp_data,
+        "random_iter": ds_random_iter,
     }
     config_kwargs = {
         k: v
@@ -274,6 +276,7 @@ def build(
     e3nn_dataset: bool | None = None,
     ds_cache: Path | None = None,
     ds_config_cache: Path | None = None,
+    ds_random_iter: bool | None = None,
     exp_file: Path | None = None,
     structures: str | None = None,
     xtal_regex: str = MPRO_ID_REGEX,
@@ -399,6 +402,7 @@ def build(
         "export_exp_data": export_exp_data,
         "grouped": grouped_dataset,
         "for_e3nn": e3nn_dataset,
+        "random_iter": ds_random_iter,
     }
 
     ds_splitter_config = {
@@ -536,6 +540,7 @@ def build_and_train(
     e3nn_dataset: bool | None = None,
     ds_cache: Path | None = None,
     ds_config_cache: Path | None = None,
+    ds_random_iter: bool | None = None,
     ds_split_type: DatasetSplitterType | None = None,
     train_frac: float | None = None,
     val_frac: float | None = None,
@@ -657,6 +662,7 @@ def build_and_train(
         "export_exp_data": export_exp_data,
         "grouped": grouped_dataset,
         "for_e3nn": e3nn_dataset,
+        "random_iter": ds_random_iter,
     }
 
     ds_splitter_config = {

--- a/asapdiscovery-ml/asapdiscovery/ml/cli_args.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/cli_args.py
@@ -1174,6 +1174,7 @@ def general_ds_args(func):
         e3nn_ds,
         ds_cache,
         ds_config_cache,
+        ds_random_iter,
     ]:
         func = fn(func)
 
@@ -1287,6 +1288,14 @@ def export_exp_data(func):
         "--export-exp-data",
         type=bool,
         help="Export the exp_data field in the DatasetConfig.",
+    )(func)
+
+
+def ds_random_iter(func):
+    return click.option(
+        "--ds-random-iter",
+        type=bool,
+        help="Randomly iterate through the dataset each time.",
     )(func)
 
 

--- a/asapdiscovery-ml/asapdiscovery/ml/dataset.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/dataset.py
@@ -39,7 +39,9 @@ class DockedDataset(Dataset):
         self.random_iter = random_iter
 
     @classmethod
-    def from_complexes(cls, complexes: list[Complex], exp_dict=None, ignore_h=True):
+    def from_complexes(
+        cls, complexes: list[Complex], exp_dict=None, ignore_h=True, random_iter=False
+    ):
         """
         Build from a list of Complex objects.
 
@@ -53,6 +55,8 @@ class DockedDataset(Dataset):
             a ligand witht that compound_id
         ignore_h : bool, default=True
             Whether to remove hydrogens from the loaded structure
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
 
         Returns
         -------
@@ -110,7 +114,7 @@ class DockedDataset(Dataset):
 
             comp_counter += 1
 
-        return cls(compound_idxs, structures)
+        return cls(compound_idxs, structures, random_iter=random_iter)
 
     @staticmethod
     def _complex_to_pose(comp, compound=None, exp_dict=None, ignore_h=True):
@@ -183,6 +187,7 @@ class DockedDataset(Dataset):
         ignore_h=True,
         extra_dict=None,
         num_workers=1,
+        random_iter=False,
     ):
         """
         Parameters
@@ -200,6 +205,8 @@ class DockedDataset(Dataset):
             keys ["z", "pos", "lig", "compound"]
         num_workers : int, default=1
             Number of cores to use to load structures
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
         """
         if extra_dict is None:
             extra_dict = {}
@@ -222,7 +229,12 @@ class DockedDataset(Dataset):
         else:
             all_complexes = [mp_func(*args) for args in mp_args]
 
-        return cls.from_complexes(all_complexes, exp_dict=extra_dict, ignore_h=ignore_h)
+        return cls.from_complexes(
+            all_complexes,
+            exp_dict=extra_dict,
+            ignore_h=ignore_h,
+            random_iter=random_iter,
+        )
 
     def __len__(self):
         return len(self.structures)

--- a/asapdiscovery-ml/asapdiscovery/ml/dataset.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/dataset.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import random
 import torch
 from asapdiscovery.data.backend.openeye import oechem
 from asapdiscovery.data.schema.complex import Complex
@@ -15,7 +16,7 @@ class DockedDataset(Dataset):
     learning.
     """
 
-    def __init__(self, compounds={}, structures=[]):
+    def __init__(self, compounds={}, structures=[], random_iter=False):
         """
         Constructor for DockedDataset object.
 
@@ -28,11 +29,14 @@ class DockedDataset(Dataset):
             List of pose dicts, containing at minimum tensors for atomic number, atomic
             positions, and a ligand idx. Indices in this list should match the indices
             in the lists in compounds.
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
         """
         super().__init__()
 
         self.compounds = compounds
         self.structures = structures
+        self.random_iter = random_iter
 
     @classmethod
     def from_complexes(cls, complexes: list[Complex], exp_dict=None, ignore_h=True):
@@ -295,8 +299,14 @@ class DockedDataset(Dataset):
             return (compounds[0], str_list[0])
 
     def __iter__(self):
-        for s in self.structures:
-            yield (s["compound"], s)
+        if self.random_iter:
+            rand_idx = random.sample(range(len(self.structures)), len(self.structures))
+            for i in rand_idx:
+                s = self.structures[i]
+                yield (s["compound"], s)
+        else:
+            for s in self.structures:
+                yield (s["compound"], s)
 
 
 class SplitDockedDataset(DockedDataset):

--- a/asapdiscovery-ml/asapdiscovery/ml/dataset.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/dataset.py
@@ -370,7 +370,12 @@ class GroupedDockedDataset(Dataset):
     for a given compound can be accessed at a time.
     """
 
-    def __init__(self, compound_ids: list[str] = [], structures: dict[str, dict] = {}):
+    def __init__(
+        self,
+        compound_ids: list[str] = [],
+        structures: dict[str, dict] = {},
+        random_iter=False,
+    ):
         """
         Constructor for GroupedDockedDataset object.
 
@@ -381,6 +386,8 @@ class GroupedDockedDataset(Dataset):
             entry in structures
         structures : dict[str, dict]
             Dict mapping compound_id to a pose dict
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
         """
         import numpy as np
 
@@ -388,9 +395,12 @@ class GroupedDockedDataset(Dataset):
 
         self.compound_ids = np.asarray(compound_ids)
         self.structures = structures
+        self.random_iter = random_iter
 
     @classmethod
-    def from_complexes(cls, complexes: list[Complex], exp_dict={}, ignore_h=True):
+    def from_complexes(
+        cls, complexes: list[Complex], exp_dict={}, ignore_h=True, random_iter=False
+    ):
         """
         Build from a list of Complex objects.
 
@@ -404,6 +414,8 @@ class GroupedDockedDataset(Dataset):
             a ligand witht that compound_id
         ignore_h : bool, default=True
             Whether to remove hydrogens from the loaded structure
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
 
         Returns
         -------
@@ -461,7 +473,9 @@ class GroupedDockedDataset(Dataset):
             # Normalize to probability, take inverse first so lower RMSDs are better
             data["rmsd_probs"] = (1 / pose_rmsds) / (1 / pose_rmsds).sum()
 
-        return cls(compound_ids=compound_ids, structures=structures)
+        return cls(
+            compound_ids=compound_ids, structures=structures, random_iter=random_iter
+        )
 
     @classmethod
     def from_files(
@@ -471,6 +485,7 @@ class GroupedDockedDataset(Dataset):
         ignore_h=True,
         extra_dict=None,
         num_workers=1,
+        random_iter=False,
     ):
         """
         Parameters
@@ -488,6 +503,8 @@ class GroupedDockedDataset(Dataset):
             keys ["z", "pos", "lig", "compound"]
         num_workers : int, default=1
             Number of cores to use to load structures
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
         """
 
         if extra_dict is None:
@@ -511,7 +528,12 @@ class GroupedDockedDataset(Dataset):
         else:
             all_complexes = [mp_func(*args) for args in mp_args]
 
-        return cls.from_complexes(all_complexes, exp_dict=extra_dict, ignore_h=ignore_h)
+        return cls.from_complexes(
+            all_complexes,
+            exp_dict=extra_dict,
+            ignore_h=ignore_h,
+            random_iter=random_iter,
+        )
 
     def __len__(self):
         return len(self.compound_ids)
@@ -576,8 +598,16 @@ class GroupedDockedDataset(Dataset):
             return (compound_id_list[0], str_list[0])
 
     def __iter__(self):
-        for compound_id in self.compound_ids:
-            yield compound_id, self.structures[compound_id]
+        if self.random_iter:
+            rand_idx = random.sample(
+                range(len(self.compound_ids)), len(self.compound_ids)
+            )
+            for i in rand_idx:
+                compound_id = self.compound_ids[i]
+                yield compound_id, self.structures[compound_id]
+        else:
+            for compound_id in self.compound_ids:
+                yield compound_id, self.structures[compound_id]
 
 
 class GraphDataset(Dataset):
@@ -585,11 +615,12 @@ class GraphDataset(Dataset):
     Class for loading SMILES as graphs.
     """
 
-    def __init__(self, compounds={}, structures=[]):
+    def __init__(self, compounds={}, structures=[], random_iter=False):
         super().__init__()
 
         self.compounds = compounds
         self.structures = structures
+        self.random_iter = random_iter
 
     @classmethod
     def from_ligands(
@@ -598,6 +629,7 @@ class GraphDataset(Dataset):
         exp_dict: dict = {},
         node_featurizer=None,
         edge_featurizer=None,
+        random_iter=False,
     ):
         """
         Parameters
@@ -612,6 +644,8 @@ class GraphDataset(Dataset):
             Featurizer for node data
         edge_featurizer : BaseBondFeaturizer, optional
             Featurizer for edges
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
         """
 
         # Function for encoding SMILES to a graph
@@ -657,7 +691,7 @@ class GraphDataset(Dataset):
                 | lig_exp_dict
             )
 
-        return cls(compounds, structures)
+        return cls(compounds, structures, random_iter=random_iter)
 
     @classmethod
     def from_exp_compounds(
@@ -666,6 +700,7 @@ class GraphDataset(Dataset):
         exp_dict: dict = {},
         node_featurizer=None,
         edge_featurizer=None,
+        random_iter=False,
     ):
         """
         Parameters
@@ -680,7 +715,8 @@ class GraphDataset(Dataset):
             Featurizer for node data
         edge_featurizer : BaseBondFeaturizer, optional
             Featurizer for edges
-            Cache file for graph dataset
+        random_iter : bool, default=False
+            Iterate through the dataset randomly each time
 
         """
         # Function for encoding SMILES to a graph
@@ -725,7 +761,7 @@ class GraphDataset(Dataset):
                 | {"date_created": exp_compound.date_created}
             )
 
-        return cls(compounds, structures)
+        return cls(compounds, structures, random_iter=random_iter)
 
     def __len__(self):
         return len(self.structures)
@@ -806,8 +842,14 @@ class GraphDataset(Dataset):
             return (compounds[0], str_list[0])
 
     def __iter__(self):
-        for s in self.structures:
-            yield (s["compound"], s)
+        if self.random_iter:
+            rand_idx = random.sample(range(len(self.structures)), len(self.structures))
+            for i in rand_idx:
+                s = self.structures[i]
+                yield (s["compound"], s)
+        else:
+            for s in self.structures:
+                yield (s["compound"], s)
 
 
 def dataset_to_dataframe(dataset):

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_dataset.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_dataset.py
@@ -66,6 +66,26 @@ def test_docked_dataset_from_files(complex_pdb):
     assert pose["pos"].shape[0] > 0
 
 
+def test_docked_dataset_random_iter(complex_pdb):
+    all_complexes = [
+        Complex.from_pdb(
+            complex_pdb,
+            target_kwargs={"target_name": f"test{i}"},
+            ligand_kwargs={"compound_name": f"test{i}"},
+        )
+        for i in range(10)
+    ]
+
+    dd = DockedDataset.from_complexes(all_complexes, random_iter=True)
+
+    # Iterate through the list twice and make sure they're not the same (should pass
+    #  unless we get really really unlucky)
+    l1 = [compound for compound, _ in dd]
+    l2 = [compound for compound, _ in dd]
+
+    assert l1 != l2
+
+
 def test_grouped_docked_dataset_from_complexes(complex_pdb):
     c1 = Complex.from_pdb(
         complex_pdb,

--- a/asapdiscovery-ml/asapdiscovery/ml/tests/test_ml_cli.py
+++ b/asapdiscovery-ml/asapdiscovery/ml/tests/test_ml_cli.py
@@ -1,3 +1,4 @@
+import itertools as it
 import json
 import pickle as pkl
 
@@ -85,12 +86,12 @@ def test_build_ds_graph(exp_file, tmp_path, export_input_data, export_exp_data):
     assert not ds_config.overwrite
 
 
+# All 3-permutations of True and False
 @pytest.mark.parametrize(
-    "export_input_data,export_exp_data",
-    [(True, True), (True, False), (False, True), (False, False)],
+    "export_input_data,export_exp_data,random_iter", it.product([True, False], repeat=3)
 )
 def test_build_ds_schnet(
-    exp_file, docked_files, tmp_path, export_input_data, export_exp_data
+    exp_file, docked_files, tmp_path, export_input_data, export_exp_data, random_iter
 ):
     docked_dir = docked_files[0].parent
 
@@ -113,6 +114,8 @@ def test_build_ds_schnet(
             tmp_path / "ds_cache.pkl",
             "--ds-config-cache",
             tmp_path / "ds_config_cache.json",
+            "--ds-random-iter",
+            random_iter,
         ],
     )
     assert result.exit_code == 0
@@ -141,6 +144,7 @@ def test_build_ds_schnet(
     assert not ds_config.grouped
     assert not ds_config.for_e3nn
     assert not ds_config.overwrite
+    assert ds.random_iter == random_iter
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
One of the experiments we want to run is to randomly iterate through the dataset each epoch. This PR should enable that, through a `random_iter` flag available to the `DockedDatset` and `DatasetConfig` classes.