### PR TITLE
xskip ML testing in CLI package

### DIFF
--- a/asapdiscovery-cli/asapdiscovery/cli/tests/test_meta_cli.py
+++ b/asapdiscovery-cli/asapdiscovery/cli/tests/test_meta_cli.py
@@ -27,7 +27,10 @@ def test_toplevel_runnable():
         "docking",
         "alchemy",
         "spectrum",
-        "ml",
+        pytest.param(
+            "ml",
+            marks=pytest.mark.xfail(reason="ML package is not currently available."),
+        ),
         "visualization",
         "simulation",
         "data",
@@ -35,9 +38,6 @@ def test_toplevel_runnable():
 )
 def test_subcommand_runnable(subcommand):
 
-    # xfail ml tests for now
-    if subcommand == "ml":
-        pytest.xfail("ML package is not currently available.")
     runner = CliRunner()
     args = [subcommand, "--help"]
     result = runner.invoke(cli, args)

--- a/asapdiscovery-cli/asapdiscovery/cli/tests/test_meta_cli.py
+++ b/asapdiscovery-cli/asapdiscovery/cli/tests/test_meta_cli.py
@@ -34,6 +34,10 @@ def test_toplevel_runnable():
     ],
 )
 def test_subcommand_runnable(subcommand):
+
+    # xfail ml tests for now
+    if subcommand == "ml":
+        pytest.xfail("ML package is not currently available.")
     runner = CliRunner()
     args = [subcommand, "--help"]
     result = runner.invoke(cli, args)


### PR DESCRIPTION
## Description
This xskips testing of ML in the CLI package, since the ML package is not currently functional with pydantic v1. 

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/asapdiscovery/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
