### PR TITLE
Fix simulation subpackage GHA workflow CI

### DIFF
--- a/devtools/conda-envs/ubuntu-latest/simulation.yaml
+++ b/devtools/conda-envs/ubuntu-latest/simulation.yaml
@@ -38,7 +38,7 @@ dependencies:
   - mdanalysis
   - openeye-toolkits
   - openff-forcefields >=2024.04.0
-  - openff-toolkit
+  - openff-toolkit-base >=0.17
   - openfe ~=1.0
   - openmm
   - openmmtools


### PR DESCRIPTION
## Description
This attempts fixing the simulation subpackage CI by pinning the minimum OpenFF toolkit base version to 0.17. This is when NAGL charges support was introduced.

This was motivated by the error message in https://github.com/choderalab/drugforge/actions/runs/19282215787/job/55135568348#step:8:104 which is complaining about NAGL support.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [ ] Point 1 ...

## Questions
- [ ] Question 1 ..

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/drugforge/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
