### PR TITLE
Replacing hash with squash-merged revision

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,4 +5,4 @@
 # last edits before merge to main
 028dfdb8b143c60fcb388a6180c7874f19b5af66
 # drugforge addition of pre-commit hook
-4ad1615e09a3bee5047db35357cb1b7688454a7c
+a89353d69db97b55e653342a70aefa14998ac57f


### PR DESCRIPTION
## Description
Ignore the blame records for the pre-commit recent addition in #124 

Just added the revision hash after merge from that one. I think that should do it.

## Status
- [ ] Ready to go


## Developers certificate of origin
- [x ] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/drugforge/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
