### PR TITLE
Set compound name to title in `to_oemol` to match behavior with `to_rdkit`

### DIFF
--- a/drugforge-data/drugforge/data/schema/ligand.py
+++ b/drugforge-data/drugforge/data/schema/ligand.py
@@ -294,7 +294,8 @@ class Ligand(DataModelAbstractBase):
 
         mol = set_SD_data(mol, data)
 
-        mol.SetTitle(self.compound_name)
+        if self.compound_name is not None:
+            mol.SetTitle(self.compound_name)
 
         return mol
 


### PR DESCRIPTION
## Description
Provide a brief description of the PR's purpose here.

## Todos
Notable points that this PR has either accomplished or will accomplish.
- [x] Set compound_name to OEMol.Title so that it is written to the sdf header

## Status
- [x] Ready to go


## Developers certificate of origin
- [x] I certify that this contribution is covered by the MIT license as defined in our [LICENSE](https://github.com/choderalab/drugforge/blob/main/LICENSE) and adheres to the [**Developer Certificate of Origin**](https://developercertificate.org/).
